### PR TITLE
relax release tools check

### DIFF
--- a/release-tools/verify-subtree.sh
+++ b/release-tools/verify-subtree.sh
@@ -30,7 +30,7 @@ if [ ! "$DIR" ]; then
     exit 1
 fi
 
-REV=$(git log -n1 --format=format:%H --no-merges -- "$DIR")
+REV=$(git log -n1 --remove-empty --format=format:%H --no-merges -- "$DIR")
 if [ "$REV" ]; then
     echo "Directory '$DIR' contains non-upstream changes:"
     echo


### PR DESCRIPTION
The situation with `release-tools` in this repo is a bit special: we have to ignore older commits which added and then removed `release-tools.

/assign @gnufied 