### PR TITLE
use a unique leader lock name

### DIFF
--- a/cmd/csi-resizer/main.go
+++ b/cmd/csi-resizer/main.go
@@ -94,7 +94,7 @@ func main() {
 		}
 		leaderElectionConfig = &util.LeaderElectionConfig{
 			Identity:      *leaderElectionIdentity,
-			LockName:      util.SanitizeName(resizerName),
+			LockName:      "external-resizer-" + util.SanitizeName(resizerName),
 			Namespace:     *leaderElectionNamespace,
 			RetryPeriod:   *leaderElectionRetryPeriod,
 			LeaseDuration: *leaderElectionLeaseDuration,


### PR DESCRIPTION
Currently both `external-provisioner` and `external-resizer` use  the driver name as leader election lock name, this may lead to unexpected conflict when they running in a same cluster.