### PR TITLE
remove permissions to endpoints for example RBAC

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -68,9 +68,6 @@ metadata:
   namespace: default
   name: external-resizer-cfg
 rules:
-- apiGroups: [""]
-  resources: ["endpoints"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

Endpoints is no longer needed since we are now using Leases for leader election