### PR TITLE
Exit on CSI gRPC conn loss

### DIFF
--- a/pkg/csi/client.go
+++ b/pkg/csi/client.go
@@ -52,7 +52,7 @@ type Client interface {
 
 // New creates a new CSI client.
 func New(address string, timeout time.Duration) (Client, error) {
-	conn, err := connection.Connect(address)
+	conn, err := connection.Connect(address, connection.OnConnectionLoss(connection.ExitOnConnectionLoss()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to CSI driver: %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
This will exit the sidecar container when its gRPC connection to the CSI driver is lost. When a CSI driver goes down, we do not want the sidecar container on that node to still be leader.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```release-note
We will now exit the external-snapshotter when the connection to a CSI driver is lost, allowing for another leader to takeover.
```
