### PR TITLE
Verify claimref associated with PVs before resizing

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -283,6 +283,11 @@ func (ctrl *resizeController) pvNeedResize(pvc *v1.PersistentVolumeClaim, pv *v1
 		return false
 	}
 
+	if (pv.Spec.ClaimRef == nil) || (pvc.Namespace != pv.Spec.ClaimRef.Namespace) || (pvc.UID != pv.Spec.ClaimRef.UID) {
+		klog.V(4).Infof("persistent volume is not bound to PVC being updated: %s", util.PVCKey(pvc))
+		return false
+	}
+
 	pvSize := pv.Spec.Capacity[v1.ResourceStorage]
 	requestSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
 	if pvSize.Cmp(requestSize) >= 0 {

--- a/pkg/csi/mock_client.go
+++ b/pkg/csi/mock_client.go
@@ -11,6 +11,7 @@ func NewMockClient(
 		name:                            name,
 		supportsNodeResize:              supportsNodeResize,
 		supportsControllerResize:        supportsControllerResize,
+		expandCalled:                    0,
 		supportsPluginControllerService: supportsPluginControllerService,
 	}
 }
@@ -20,6 +21,7 @@ type MockClient struct {
 	supportsNodeResize              bool
 	supportsControllerResize        bool
 	supportsPluginControllerService bool
+	expandCalled                    int
 	usedSecrets                     map[string]string
 }
 
@@ -45,8 +47,13 @@ func (c *MockClient) Expand(
 	requestBytes int64,
 	secrets map[string]string) (int64, bool, error) {
 	// TODO: Determine whether the operation succeeds or fails by parameters.
+	c.expandCalled++
 	c.usedSecrets = secrets
 	return requestBytes, c.supportsNodeResize, nil
+}
+
+func (c *MockClient) GetExpandCount() int {
+	return c.expandCalled
 }
 
 // GetSecrets returns secrets used for volume expansion


### PR DESCRIPTION
Verify claimref associated with PVs before doing pvc resizing.

cc @msau42 @jsafrane 

```release-note
Verify claimref associated with PVs before doing pvc resizing.
```