### PR TITLE
Omit extranous dash with CSI timeout parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Note that the external-resizer does not scale with more replicas. Only one exter
 
 * `--leader-election-namespace`: Namespace where the leader election resource lives. Defaults to the pod namespace if not set.
 
-* `---csiTimeout <duration>`: Timeout of all calls to CSI driver. It should be set to value that accommodates majority of `ControllerExpandVolume` calls. 15 seconds is used by default.
+* `--csiTimeout <duration>`: Timeout of all calls to CSI driver. It should be set to value that accommodates majority of `ControllerExpandVolume` calls. 15 seconds is used by default.
 
 * `--workers <num>`: Number of simultaneously running `ControllerExpandVolume` operations. Default value is `10`.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig-storage