### PR TITLE
Ability to customize PVC workqueue retry interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Note that the external-resizer does not scale with more replicas. Only one exter
 
 * `--csiTimeout <duration>`: Timeout of all calls to CSI driver. It should be set to value that accommodates majority of `ControllerExpandVolume` calls. 15 seconds is used by default.
 
+* `--retry-interval-start`: The starting value of the exponential backoff for failures. 1 second is used by default.
+
+* `--retry-interval-max`: The exponential backoff maximum value. 5 minutes is used by default.
+
 * `--workers <num>`: Number of simultaneously running `ControllerExpandVolume` operations. Default value is `10`.
 
 * `--metrics-address`: The TCP network address where the prometheus metrics endpoint will run (example: `:8080` which corresponds to port 8080 on local host). The default is empty string, which means metrics endpoint is disabled.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -65,7 +65,8 @@ func NewResizeController(
 	resizer resizer.Resizer,
 	kubeClient kubernetes.Interface,
 	resyncPeriod time.Duration,
-	informerFactory informers.SharedInformerFactory) ResizeController {
+	informerFactory informers.SharedInformerFactory,
+	pvcRateLimiter workqueue.RateLimiter) ResizeController {
 	pvInformer := informerFactory.Core().V1().PersistentVolumes()
 	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 
@@ -76,7 +77,7 @@ func NewResizeController(
 		v1.EventSource{Component: fmt.Sprintf("external-resizer %s", name)})
 
 	claimQueue := workqueue.NewNamedRateLimitingQueue(
-		workqueue.DefaultControllerRateLimiter(), fmt.Sprintf("%s-pvc", name))
+		pvcRateLimiter, fmt.Sprintf("%s-pvc", name))
 
 	ctrl := &resizeController{
 		name:          name,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"k8s.io/client-go/util/workqueue"
 	"testing"
 	"time"
 
@@ -123,7 +124,7 @@ func TestController(t *testing.T) {
 			t.Fatalf("Test %s: Unable to create resizer: %v", test.Name, err)
 		}
 
-		controller := NewResizeController(driverName, csiResizer, kubeClient, time.Second, informerFactory)
+		controller := NewResizeController(driverName, csiResizer, kubeClient, time.Second, informerFactory, workqueue.DefaultControllerRateLimiter())
 		err = controller.(*resizeController).syncPVC(fmt.Sprintf("%s/%s", test.PVC.Namespace, test.PVC.Name))
 		if err != nil {
 			t.Fatalf("Test %s: Unexpected error: %v", test.Name, err)


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Specify back-off parameters for the PVC workqueue.
Shamelessly aped off https://github.com/kubernetes-csi/external-attacher/pull/141.

```release-note
NONE
```
