### PR TITLE
Replace `csiTimeout` to `timeout` param for resizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Note that the external-resizer does not scale with more replicas. Only one exter
 
 * `--leader-election-namespace`: Namespace where the leader election resource lives. Defaults to the pod namespace if not set.
 
-* `--csiTimeout <duration>`: Timeout of all calls to CSI driver. It should be set to value that accommodates majority of `ControllerExpandVolume` calls. 15 seconds is used by default.
+* `--timeout <duration>`: Timeout of all calls to CSI driver. It should be set to value that accommodates majority of `ControllerExpandVolume` calls. 10 seconds is used by default.
 
 * `--retry-interval-start`: The starting value of the exponential backoff for failures. 1 second is used by default.
 

--- a/cmd/csi-resizer/main.go
+++ b/cmd/csi-resizer/main.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"time"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"time"
 
 	"k8s.io/client-go/util/workqueue"
 
@@ -44,8 +45,9 @@ var (
 	resyncPeriod = flag.Duration("resync-period", time.Minute*10, "Resync period for cache")
 	workers      = flag.Int("workers", 10, "Concurrency to process multiple resize requests")
 
-	csiAddress  = flag.String("csi-address", "/run/csi/socket", "Address of the CSI driver socket.")
-	csiTimeout  = flag.Duration("csiTimeout", 15*time.Second, "Timeout for waiting for CSI driver socket.")
+	csiAddress = flag.String("csi-address", "/run/csi/socket", "Address of the CSI driver socket.")
+	timeout    = flag.Duration("timeout", 10*time.Second, "Timeout for waiting for CSI driver socket.")
+
 	showVersion = flag.Bool("version", false, "Show version")
 
 	retryIntervalStart = flag.Duration("retry-interval-start", time.Second, "Initial retry interval of failed volume resize. It exponentially increases with each failure, up to retry-interval-max.")
@@ -99,7 +101,7 @@ func main() {
 
 	csiResizer, err := resizer.NewResizer(
 		*csiAddress,
-		*csiTimeout,
+		*timeout,
 		kubeClient,
 		informerFactory,
 		*metricsAddress,


### PR DESCRIPTION
At present the resizer has CSI call timeout value
taken as arg in form of `--csiTimeout` , however all
other sidecars have this parameter as `--timeout`.
This patch replaces `csiTimeout` to `timeout` value

NOTE: This is a breaking change, so we need a new release

```release-note
The `--csiTimeout` flag of external-resizer is obsoleted with this release. Instead `--timeout` flag has been introduced for the same purpose. The   timeout value  accommodates majority of `ControllerExpandVolume` calls. `timeout` value defaults to 10 seconds. From now on, the deployment  templates or  artifacts has to make use of `--timeout` flag instead of obsoleted `--csiTimeout`  flag.
```
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

