### PR TITLE
Make Pod informer registration optional

### DIFF
--- a/cmd/csi-resizer/main.go
+++ b/cmd/csi-resizer/main.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"k8s.io/client-go/util/workqueue"
 	"os"
 	"time"
+
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	"github.com/kubernetes-csi/external-resizer/pkg/controller"
@@ -52,6 +53,8 @@ var (
 
 	metricsAddress = flag.String("metrics-address", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
 	metricsPath    = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
+
+	handleVolumeInUseError = flag.Bool("handle-volume-inuse-error", true, "Flag to turn on/off capability to handle volume in use error in resizer controller. Defaults to true if not set.")
 
 	version = "unknown"
 )
@@ -88,7 +91,7 @@ func main() {
 	resizerName := csiResizer.Name()
 	rc := controller.NewResizeController(resizerName, csiResizer, kubeClient, *resyncPeriod, informerFactory,
 		workqueue.NewItemExponentialFailureRateLimiter(*retryIntervalStart, *retryIntervalMax),
-	)
+		*handleVolumeInUseError)
 	run := func(ctx context.Context) {
 		informerFactory.Start(wait.NeverStop)
 		rc.Run(*workers, ctx)


### PR DESCRIPTION
Changes:
1. Added support for feature gate flag parsing
2. Register Pod informer only if feature is enabled.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Pods watch is an expensive operation. Hence make the feature of handling volume in use errors optional, by registering pod informer based on a feature gate
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #88 

**Special notes for your reviewer**:
The changes have been tested by using the resizer sidecar along with GCE Persistent Disk driver for 2 scenario:
1. The feature flag off, and make sure kubernetes e2e volume-expand test succeeds, without any changes to rbac rules for resizer (i.e no pod events watch permissions)
2. The feature flag on, and make sure kubernetes e2e volume-expand test succeeds, without changes to rbac rules for resizer (i.e pod events watch permissions)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Pods watch is an expensive operation. Hence make the feature of handling volume in use errors optional, by registering pod informer based on a feature gate
```
