### PR TITLE
Configurable QPS and Burst for k8s clients

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"regexp"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,32 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 var knownResizeConditions = map[v1.PersistentVolumeClaimConditionType]bool{
 	v1.PersistentVolumeClaimResizing:                true,
 	v1.PersistentVolumeClaimFileSystemResizePending: true,
-}
-
-// NewK8sClient is an utility function used to create a kubernetes sdk client.
-func NewK8sClient(master, kubeConfig string) (kubernetes.Interface, error) {
-	var config *rest.Config
-	var err error
-	if master != "" || kubeConfig != "" {
-		config, err = clientcmd.BuildConfigFromFlags(master, kubeConfig)
-	} else {
-		config, err = rest.InClusterConfig()
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to create config: %v", err)
-	}
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client: %v", err)
-	}
-	return kubeClient, nil
 }
 
 // PVCKey returns an unique key of a PVC object,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As a follow up to https://github.com/kubernetes-csi/external-provisioner/commit/550c67a6cc47dd4d8756b1617a3c7057c293b110, setting configurable QPS and Burst for k8s client on external-resizer as well. 
Defaults remain the same. Making QPS and Burst configurable is useful for different test/dev environments. 


**Testing**
Kubernetes version: 1.16.3
CSI driver: dummy vSphere CSI driver with `ControllerExpandVolume` always returning true. `NodeExpansionRequired` is set to `true` so PVCs enter `FileSystemResizePending`. 
The test is to resize pre existing PVCs in a loop in 10 threads for 120 seconds and calculate throughput. `--workers=10` is set on external-resizer. 
I've also collected the count of `Throttling ...` log messages. Throttling to API server includes:
1. POSTing events to default namespace
```
{"log":"I0721 04:20:56.702693       1 request.go:557] Throttling request took 150.40211ms, request: POST:https://10.96.0.1:443/api/v1/namespaces/default/events\n","stream":"stderr","time":"2020-07-21T04:20:56.702931438Z"}
```

2. PATCHing PVCs
```
{"log":"I0721 04:20:57.302786       1 request.go:557] Throttling request took 602.542657ms, request: PATCH:https://10.96.0.1:443/api/v1/namespaces/default/persistentvolumeclaims/blkvol-51715-0-2/status\n","stream":"stderr","time":"2020-07-21T04:20:57.30307503Z"}
```

3. PATCHing PVs
```
{"log":"I0721 04:20:56.902876       1 request.go:557] Throttling request took 349.273437ms, request: PATCH:https://10.96.0.1:443/api/v1/persistentvolumes/pvc-9543191c-e997-4eec-808c-73bc0cba095d\n","stream":"stderr","time":"2020-07-21T04:20:56.903118114Z"}
```
  
Results after configuring QPS and Burst:


1. QPS = 5.0, Burst = 10 (Default)
a. Number of operations: 133
b. Throughput: 1.127
c. Number of throttling messages seen: 
```
root@k8-master-885:/var/log/containers# cat vsphere-csi-controller-6c6dbbd768-dgp5j_kube-system_csi-resizer-2bb80d4bb764c3b463dc528a2551876872054ce49133c37a02d08112af376798.log | grep Thrott | wc -l
932
```
2. QPS = 10.0, Burst = 25
a. Number of operations: 269
b. Throughput: 2.261
c. Number of throttling messages seen: 
```
root@k8-master-885:/var/log/containers# cat vsphere-csi-controller-65d94998f4-475lj_kube-system_csi-resizer-4f151e5fabfdb4c2400374c2648ea75192a3cc52087ba191bab5b12c66bb742f.log | grep Thrott | wc -l
1530
```

3. QPS = 25.0, Burst = 50
a. Number of operations: 626
b. Throughput: 5.261
c. Number of throttling messages seen: 
```
root@k8-master-885:/var/log/containers# cat vsphere-csi-controller-55cc8f964b-cdkt9_kube-system_csi-resizer-190362ec40f923459969181a52e954487d88202d48fb9ea7a54d037f556f2905.log | grep Thrott | wc -l
2948
```

4. QPS = 50.0, Burst = 100
a. Number of operations: 952
b. Throughput: 8.000
c. Number of throttling messages seen: 
```
root@k8-master-885:/var/log/containers# cat vsphere-csi-controller-5b78c46bf4-gvzzb_kube-system_csi-resizer-aa4fd77f433d1fd16babc68820a3248f11b211afd858bcca4224c06b75df91fb.log | grep Thrott | wc -l
813
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adding configurable QPS and Burst to k8s client and use a separate client for leader election. 
```
