### PR TITLE
Exit container if informer caches fail to sync

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -248,8 +248,7 @@ func (ctrl *resizeController) Run(
 	}
 
 	if !cache.WaitForCacheSync(stopCh, informersSyncd...) {
-		klog.Errorf("Cannot sync pod, pv or pvc caches")
-		return
+		klog.Fatalf("Cannot sync pod, pv or pvc caches")
 	}
 
 	for i := 0; i < workers; i++ {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR ensures the resizer container exits if informer caches fail to sync. 

Before this change, resizer `Run()` function would exit but the container would not restart. 
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl logs vsphere-csi-controller-5594766d5b-p6q2z -n kube-system -c csi-resizer -f
I1007 22:13:51.988959       1 main.go:79] Version : v1.0.0-rc2
I1007 22:13:51.995046       1 connection.go:153] Connecting to unix:///csi/csi.sock
I1007 22:13:52.000134       1 common.go:111] Probing CSI driver for readiness
I1007 22:13:52.013139       1 csi_resizer.go:77] CSI driver name: "csi.vsphere.vmware.com"
W1007 22:13:52.013753       1 metrics.go:142] metrics endpoint will not be started because `metrics-address` was not specified.
I1007 22:13:52.022003       1 controller.go:114] Register Pod informer for resizer csi.vsphere.vmware.com
I1007 22:13:52.026512       1 main.go:136] 1
I1007 22:13:52.027627       1 leaderelection.go:243] attempting to acquire leader lease  kube-system/external-resizer-csi-vsphere-vmware-com...
I1007 22:13:52.079012       1 leader_election.go:172] new leader detected, current leader: vsphere-csi-controller-5594766d5b-5vh99
I1007 22:14:11.410440       1 leaderelection.go:253] successfully acquired lease kube-system/external-resizer-csi-vsphere-vmware-com
I1007 22:14:11.410624       1 leader_election.go:172] new leader detected, current leader: vsphere-csi-controller-5594766d5b-p6q2z
I1007 22:14:11.411511       1 leader_election.go:165] became leader, starting
I1007 22:14:11.411683       1 controller.go:238] Starting external resizer csi.vsphere.vmware.com
I1007 22:14:11.612176       1 controller.go:248] Cannot sync pod, pv or pvc caches
I1007 22:14:11.612201       1 controller.go:253] Shutting down external resizer csi.vsphere.vmware.com
^C

root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl get pod -n kube-system
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-5594766d5b-p6q2z   6/6     Running   0          6m30s
```

After this change, the container restarts
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl logs vsphere-csi-controller-5594766d5b-2pgr8 -n kube-system -c csi-resizer -f
I1007 22:25:52.340282       1 main.go:79] Version : v1.0.0-rc2-2-gae8826a-dirty
I1007 22:25:52.350996       1 connection.go:153] Connecting to unix:///csi/csi.sock
I1007 22:25:52.359212       1 common.go:111] Probing CSI driver for readiness
I1007 22:25:52.372515       1 csi_resizer.go:77] CSI driver name: "csi.vsphere.vmware.com"
W1007 22:25:52.372715       1 metrics.go:142] metrics endpoint will not be started because `metrics-address` was not specified.
I1007 22:25:52.427399       1 controller.go:114] Register Pod informer for resizer csi.vsphere.vmware.com
I1007 22:25:52.428365       1 main.go:136] 1
I1007 22:25:52.428523       1 leaderelection.go:243] attempting to acquire leader lease  kube-system/external-resizer-csi-vsphere-vmware-com...
I1007 22:25:52.521823       1 leaderelection.go:253] successfully acquired lease kube-system/external-resizer-csi-vsphere-vmware-com
I1007 22:25:52.523369       1 leader_election.go:165] became leader, starting
I1007 22:25:52.523759       1 controller.go:238] Starting external resizer csi.vsphere.vmware.com
I1007 22:25:52.523890       1 leader_election.go:172] new leader detected, current leader: vsphere-csi-controller-5594766d5b-2pgr8
F1007 22:25:52.734074       1 controller.go:248] Cannot sync pod, pv or pvc caches
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl get pod -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-5594766d5b-2pgr8   5/6     Error     1          41s
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #113

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Exit container if resizer fails to sync informer caches.
```
