### PR TITLE
Fix the failing multiarch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest-amd64
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI External Resizer"
 ARG binary=./bin/csi-resizer


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: As distroless image is now multiarch, image push job fails on s390x and ppc64le due to lack of support.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes-csi/csi-release-tools/issues/105

**Special notes for your reviewer**: Workaround to allow builds to pass while we add support to distroless image.

**Does this PR introduce a user-facing change?**: 
```release-note
Changing distroless base image from multiarch to -amd64 to fix Prow builds
```

cc @msau42 