### PR TITLE
added labels to the resources to be used for collective operation

### DIFF
--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -6,6 +6,8 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-resizer
+  labels:
+    app: csi-resizer
 spec:
   replicas: 1
   selector:

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -14,6 +14,8 @@ metadata:
   name: csi-resizer
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-resizer
 
 ---
 # Resizer must be able to work with PVCs, PVs, SCs.
@@ -21,6 +23,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-resizer-runner
+  labels:
+    app: csi-resizer
 rules:
   # The following rule should be uncommented for plugins that require secrets
   # for provisioning.
@@ -48,6 +52,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-resizer-role
+  labels:
+    app: csi-resizer
 subjects:
   - kind: ServiceAccount
     name: csi-resizer
@@ -67,6 +73,8 @@ metadata:
   # replace with non-default namespace name
   namespace: default
   name: external-resizer-cfg
+  labels:
+    app: csi-resizer
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
We need to add the common/generic labels to all the resources which are being deployed as the part of any csi driver. It is the part of this [PR](https://github.com/kubernetes-csi/csi-driver-host-path/pull/216)

Special notes for your reviewer:
Since there was no common labels to identify all the items in one set of resources installed, these labels can help us to identify resources and operate on them in a collective manner

Does this PR introduce a user-facing change?:

NONE
