### PR TITLE
release-1.1: update release-tools

### DIFF
--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -21,6 +21,7 @@ aliases:
   - chrishenzie
   - ggriffiths
   - gnufied
+  - humblec
   - j-griffith
   - Jiawei0227
   - jingxu97

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -95,7 +95,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Check [image build status](https://k8s-testgrid.appspot.com/sig-storage-image-build).
 1. Promote images from k8s-staging-sig-storage to k8s.gcr.io/sig-storage. From
    the [k8s image
-   repo](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io/images/k8s-staging-sig-storage),
+   repo](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io/images/k8s-staging-sig-storage),
    run `./generate.sh > images.yaml`, and send a PR with the updated images.
    Once merged, the image promoter will copy the images from staging to prod.
 1. Update [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs) sidecar

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -13,7 +13,7 @@
 # See https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
 # for more details on image pushing process in Kubernetes.
 #
-# To promote release images, see https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io/images/k8s-staging-sig-storage.
+# To promote release images, see https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
 # Building three images in external-snapshotter takes roughly half an hour,


### PR DESCRIPTION
Squashed 'release-tools/' changes from f325590..c0a4fb1

[c0a4fb1](https://github.com/kubernetes-csi/csi-release-tools/commit/c0a4fb1) Merge [pull request #164](https://github.com/kubernetes-csi/csi-release-tools/pull/164) from anubha-v-ardhan/patch-1
[9c6a6c0](https://github.com/kubernetes-csi/csi-release-tools/commit/9c6a6c0) Master to main cleanup
[682c686](https://github.com/kubernetes-csi/csi-release-tools/commit/682c686) Merge [pull request #162](https://github.com/kubernetes-csi/csi-release-tools/pull/162) from pohly/pod-name-via-shell-command
[36a29f5](https://github.com/kubernetes-csi/csi-release-tools/commit/36a29f5) Merge [pull request #163](https://github.com/kubernetes-csi/csi-release-tools/pull/163) from pohly/remove-bazel
[68e43ca](https://github.com/kubernetes-csi/csi-release-tools/commit/68e43ca) prow.sh: remove Bazel build support
[c5f59c5](https://github.com/kubernetes-csi/csi-release-tools/commit/c5f59c5) prow.sh: allow shell commands in CSI_PROW_SANITY_POD
[71c810a](https://github.com/kubernetes-csi/csi-release-tools/commit/71c810a) Merge [pull request #161](https://github.com/kubernetes-csi/csi-release-tools/pull/161) from pohly/mock-test-fixes
[9e438f8](https://github.com/kubernetes-csi/csi-release-tools/commit/9e438f8) prow.sh: fix mock testing
[d7146c7](https://github.com/kubernetes-csi/csi-release-tools/commit/d7146c7) Merge [pull request #160](https://github.com/kubernetes-csi/csi-release-tools/pull/160) from pohly/kind-update
[4b6aa60](https://github.com/kubernetes-csi/csi-release-tools/commit/4b6aa60) prow.sh: update to KinD v0.11.0
[7cdc76f](https://github.com/kubernetes-csi/csi-release-tools/commit/7cdc76f) Merge [pull request #159](https://github.com/kubernetes-csi/csi-release-tools/pull/159) from pohly/fix-deployment-selection
[ef8bd33](https://github.com/kubernetes-csi/csi-release-tools/commit/ef8bd33) prow.sh: more flexible CSI_PROW_DEPLOYMENT, part II
[204bc89](https://github.com/kubernetes-csi/csi-release-tools/commit/204bc89) Merge [pull request #158](https://github.com/kubernetes-csi/csi-release-tools/pull/158) from pohly/fix-deployment-selection
[61538bb](https://github.com/kubernetes-csi/csi-release-tools/commit/61538bb) prow.sh: more flexible CSI_PROW_DEPLOYMENT
[2b0e6db](https://github.com/kubernetes-csi/csi-release-tools/commit/2b0e6db) Merge [pull request #157](https://github.com/kubernetes-csi/csi-release-tools/pull/157) from humblec/csi-release
[a2fcd6d](https://github.com/kubernetes-csi/csi-release-tools/commit/a2fcd6d) Adding myself to csi reviewers group

git-subtree-dir: release-tools
git-subtree-split: c0a4fb1dd00b02879dbcea987e2e9524e4f5a905

```release-note
NONE
```