### PR TITLE
replace map with set in inUsePVCStore

### DIFF
--- a/pkg/controller/inuse_pvc_store_test.go
+++ b/pkg/controller/inuse_pvc_store_test.go
@@ -79,15 +79,15 @@ func TestAddRemovePods(t *testing.T) {
 		initialObjects   []runtime.Object
 		addPod           *v1.Pod
 		removePod        *v1.Pod
-		expectedInUsePVC map[string]map[UniquePodName]UniquePodName
+		expectedInUsePVC map[string]map[UniquePodName]struct{}
 	}{
 		{
 			name:           "with no initial pods",
 			initialObjects: []runtime.Object{},
 			addPod:         withPVC("no-init-pod", pod()),
-			expectedInUsePVC: map[string]map[UniquePodName]UniquePodName{
+			expectedInUsePVC: map[string]map[UniquePodName]struct{}{
 				"default/no-init-pod": {
-					UniquePodName(defaultUID): UniquePodName(defaultUID),
+					UniquePodName(defaultUID): struct{}{},
 				},
 			},
 		},
@@ -95,13 +95,13 @@ func TestAddRemovePods(t *testing.T) {
 			name:             "adding failed pod",
 			initialObjects:   []runtime.Object{},
 			addPod:           withStatus(v1.PodFailed, withPVC("foobar", pod())),
-			expectedInUsePVC: map[string]map[UniquePodName]UniquePodName{},
+			expectedInUsePVC: map[string]map[UniquePodName]struct{}{},
 		},
 		{
 			name:             "with success pod",
 			initialObjects:   []runtime.Object{},
 			addPod:           withStatus(v1.PodSucceeded, withPVC("foobar", pod())),
-			expectedInUsePVC: map[string]map[UniquePodName]UniquePodName{},
+			expectedInUsePVC: map[string]map[UniquePodName]struct{}{},
 		},
 		{
 			name: "removing running pod",
@@ -109,7 +109,7 @@ func TestAddRemovePods(t *testing.T) {
 				withUID(types.UID("foobar-pod"), pod()),
 			},
 			removePod:        withUID(types.UID("foobar-pod"), pod()),
-			expectedInUsePVC: map[string]map[UniquePodName]UniquePodName{},
+			expectedInUsePVC: map[string]map[UniquePodName]struct{}{},
 		},
 		{
 			name: "removing failed pod",
@@ -117,7 +117,7 @@ func TestAddRemovePods(t *testing.T) {
 				withUID(types.UID("foobar-pod"), pod()),
 			},
 			removePod:        withStatus(v1.PodFailed, withUID(types.UID("foobar-pod"), pod())),
-			expectedInUsePVC: map[string]map[UniquePodName]UniquePodName{},
+			expectedInUsePVC: map[string]map[UniquePodName]struct{}{},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind cleanup

**What this PR does / why we need it**:

Improve the code quality of `inUsePVCStore`. What we need here is just a set for deduplication so using `map[]struct{}` is better.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
