### PR TITLE
Fix few golangci-lint warnings

### DIFF
--- a/pkg/controller/inuse_pvc_store_test.go
+++ b/pkg/controller/inuse_pvc_store_test.go
@@ -28,7 +28,6 @@ import (
 
 const (
 	defaultNS       = "default"
-	defaultPVCName  = "pvc1"
 	defaultPodName  = "pod1"
 	defaultNodeName = "node1"
 	defaultUID      = "uid1"

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -17,6 +17,7 @@ limitations under the License.
 package features
 
 import (
+	"k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
 )
@@ -34,7 +35,7 @@ const (
 )
 
 func init() {
-	utilfeature.DefaultMutableFeatureGate.Add(defaultResizerFeatureGates)
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultResizerFeatureGates))
 }
 
 var defaultResizerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{

--- a/pkg/resizer/csi_resizer.go
+++ b/pkg/resizer/csi_resizer.go
@@ -283,11 +283,3 @@ func getCredentials(k8sClient kubernetes.Interface, ref *v1.SecretReference) (ma
 	}
 	return credentials, nil
 }
-
-func uniqueAccessModes(pvSpec v1.PersistentVolumeSpec) map[v1.PersistentVolumeAccessMode]bool {
-	m := map[v1.PersistentVolumeAccessMode]bool{}
-	for _, mode := range pvSpec.AccessModes {
-		m[mode] = true
-	}
-	return m
-}


### PR DESCRIPTION
/kind cleanup

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
