### PR TITLE
Fix unnecessary warning when PV bound to PVC is not created yet

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -310,6 +310,11 @@ func (ctrl *resizeController) syncPVC(key string) error {
 		return fmt.Errorf("expected PVC got: %v", pvcObject)
 	}
 
+	if pvc.Spec.VolumeName == "" {
+		klog.V(4).Infof("PV bound to PVC %q is not created yet", util.PVCKey(pvc))
+		return nil
+	}
+
 	volumeObj, exists, err := ctrl.volumes.GetByKey(pvc.Spec.VolumeName)
 	if err != nil {
 		return fmt.Errorf("Get PV %q of pvc %q failed: %v", pvc.Spec.VolumeName, util.PVCKey(pvc), err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR adds the empty check of pvc.Spec.VolumeName before getting the PV to avoid an unnecessary warning [here](https://github.com/kubernetes-csi/external-resizer/blob/v1.2.0/pkg/controller/controller.go#L318) that is logged every time a new PVC is created.

before:
```
I0816 07:50:11.380497       1 controller.go:291] Started PVC processing "default/sample-volume-jtdql"
W0816 07:50:11.380594       1 controller.go:318] PV "" bound to PVC default/sample-volume-jtdql not found
```

after:
```
I0818 08:00:08.852855       1 controller.go:291] Started PVC processing "default/sample-volume-v2784"
I0818 08:00:08.855161       1 controller.go:314] PV bound to PVC "default/sample-volume-v2784" is not created yet
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #170

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix unnecessary warning when PV bound to PVC is not created yet.
```
