### PR TITLE
implement distributed resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ Note that the external-resizer does not scale with more replicas. Only one exter
 
 ### Distributed Resizing
 
-The distributed resizing feature is provided to handle resize operations for local volumes. To use this functionality, the resizer sidecar should be deployed along with the csi driver on each node so that every node manages the resize operations only for the volumes local to that node. This feature can be enabled by setting the following command line options to true:
+The distributed resizing feature is provided to handle resize operations for local volumes. To use this functionality, the resizer sidecar should be deployed along with the csi driver on each node so that every node manages the resize operations only for the volumes local to that node. This feature can be enabled by setting the following command line option to true:
 
 * `--node-deployment`: Enables the resizer sidecar to handle resize operations for the volumes local to the node on which it is deployed. Off by default.
 
-Other than this, the NODE_NAME environment variable must be set where the CSI snapshotter sidecar is deployed. The value of NODE_NAME should be the name of the node where the sidecar is running.
+Other than this, the NODE_NAME environment variable must be set where the CSI resizer sidecar is deployed. The value of NODE_NAME should be the name of the node where the sidecar is running.
 
 
 ### HTTP endpoint

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Note that the external-resizer does not scale with more replicas. Only one exter
 
 * `--timeout <duration>`: Timeout of all calls to CSI driver. It should be set to value that accommodates majority of `ControllerExpandVolume` calls. 10 seconds is used by default.
 
+* `--node-deployment`: Enables the resizer sidecar to handle resize operations for the volumes local to the node on which it is deployed. Off by default.
+
 * `-kube-api-burst <int>` : Burst to use while communicating with the kubernetes apiserver. Defaults to 10. (default 10).
 
 * `-kube-api-qps <float>` : QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0. (default 5).
@@ -96,6 +98,16 @@ Note that the external-resizer does not scale with more replicas. Only one exter
 * `--version`: Prints current external-resizer version and quits.
 
 * All glog / klog arguments are supported, such as `-v <log level>` or `-alsologtostderr`.
+
+
+### Distributed Resizing
+
+The distributed resizing feature is provided to handle resize operations for local volumes. To use this functionality, the resizer sidecar should be deployed along with the csi driver on each node so that every node manages the resize operations only for the volumes local to that node. This feature can be enabled by setting the following command line options to true:
+
+* `--node-deployment`: Enables the resizer sidecar to handle resize operations for the volumes local to the node on which it is deployed. Off by default.
+
+Other than this, the NODE_NAME environment variable must be set where the CSI snapshotter sidecar is deployed. The value of NODE_NAME should be the name of the node where the sidecar is running.
+
 
 ### HTTP endpoint
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -233,7 +233,7 @@ func TestController(t *testing.T) {
 		pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 		podInformer := informerFactory.Core().V1().Pods()
 
-		csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+		csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName, false)
 		if err != nil {
 			t.Fatalf("Test %s: Unable to create resizer: %v", test.Name, err)
 		}
@@ -365,7 +365,7 @@ func TestResizePVC(t *testing.T) {
 		pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 		podInformer := informerFactory.Core().V1().Pods()
 
-		csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+		csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName, false)
 		if err != nil {
 			t.Fatalf("Test %s: Unable to create resizer: %v", test.Name, err)
 		}

--- a/pkg/controller/expand_and_recover_test.go
+++ b/pkg/controller/expand_and_recover_test.go
@@ -117,7 +117,7 @@ func TestExpandAndRecover(t *testing.T) {
 
 			kubeClient, informerFactory := fakeK8s(initialObjects)
 
-			csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName, false)
 			if err != nil {
 				t.Fatalf("Test %s: Unable to create resizer: %v", test.name, err)
 			}

--- a/pkg/resizer/csi_resizer_test.go
+++ b/pkg/resizer/csi_resizer_test.go
@@ -68,7 +68,7 @@ func TestNewResizer(t *testing.T) {
 		client := csi.NewMockClient("mock", c.SupportsNodeResize, c.SupportsControllerResize, c.SupportsPluginControllerService, c.SupportsControllerSingleNodeMultiWriter)
 		driverName := "mock-driver"
 		k8sClient, informerFactory := fakeK8s()
-		resizer, err := NewResizerFromClient(client, 0, k8sClient, informerFactory, driverName)
+		resizer, err := NewResizerFromClient(client, 0, k8sClient, informerFactory, driverName, false)
 		if err != c.Error {
 			t.Errorf("Case %d: Unexpected error: wanted %v, got %v", i, c.Error, err)
 		}
@@ -160,7 +160,7 @@ func TestResizeMigratedPV(t *testing.T) {
 			client := csi.NewMockClient(driverName, true, true, true, true)
 			client.SetCheckMigratedLabel()
 			k8sClient, informerFactory := fakeK8s()
-			resizer, err := NewResizerFromClient(client, 0, k8sClient, informerFactory, driverName)
+			resizer, err := NewResizerFromClient(client, 0, k8sClient, informerFactory, driverName, false)
 			if err != nil {
 				t.Fatalf("Failed to create resizer: %v", err)
 			}
@@ -428,7 +428,7 @@ func TestCanSupport(t *testing.T) {
 			driverName := tc.driverName
 			client := csi.NewMockClient(driverName, true, true, true, true)
 			k8sClient, informerFactory := fakeK8s()
-			resizer, err := NewResizerFromClient(client, 0, k8sClient, informerFactory, driverName)
+			resizer, err := NewResizerFromClient(client, 0, k8sClient, informerFactory, driverName, false)
 			if err != nil {
 				t.Fatalf("Failed to create resizer: %v", err)
 			}

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -27,5 +27,6 @@ const (
 const (
 	// If CSI migration is enabled, the value will be CSI driver name
 	// Otherwise, it will be in-tree storage plugin name
-	VolumeResizerKey = "volume.kubernetes.io/storage-resizer"
+	VolumeResizerKey      = "volume.kubernetes.io/storage-resizer"
+	VolumeSelectedNodeKey = "volume.kubernetes.io/selected-node"
 )


### PR DESCRIPTION
Signed-off-by: Travis Glenn Hansen <travisghansen@yahoo.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add resizing support to distributed setups to compliement provisioner and snapshotter features of the same nature.

1. Added a parameter "--node-deployment" as a command line option for resizer sidecar, which should be set to true when the sidecar is being deployed on a per node basis.
1. For these changes to work, NODE_NAME environment variable must also be set while deploying the sidecar controller.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #142 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds support for distributed resizing.
```
