### PR TITLE
[Backoport][release-1.2] Fix: PVC used by a job doesn't get resize after the pod of the job completed

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -161,7 +161,11 @@ func (ctrl *resizeController) updatePod(oldObj, newObj interface{}) {
 		return
 	}
 
-	ctrl.usedPVCs.addPod(pod)
+	if isPodTerminated(pod) {
+		ctrl.usedPVCs.removePod(pod)
+	} else {
+		ctrl.usedPVCs.addPod(pod)
+	}
 }
 
 func (ctrl *resizeController) updatePVC(oldObj, newObj interface{}) {


### PR DESCRIPTION
Once the job pod is terminated, remove the corresponding PVC from the
usedPVCs.

Signed-off-by: Phan Le <phan.le@suse.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #175

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
