### PR TITLE
rbac: remove unwanted rbac for leader election

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -59,7 +59,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-# Resizer must be able to work with end point in current namespace
+# Resizer must be able to work with `leases` in current namespace
 # if (and only if) leadership election is enabled
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Endpoint  RBAC was removed via https://github.com/kubernetes-csi/external-resizer/commit/15a912cfe617c0d38a84cd2b8639c2013b912358 , however the comment was not adjusted which is
addressed in this PR.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

/kind cleanup

-->
```release-note
NONE
```
