### PR TITLE
release-1.2: update release-tools

### DIFF
--- a/release-tools/verify-spelling.sh
+++ b/release-tools/verify-spelling.sh
@@ -41,7 +41,7 @@ if [[ -z "$(command -v misspell)" ]]; then
   # perform go get in a temp dir as we are not tracking this version in a go module
   # if we do the go get in the repo, it will create / update a go.mod and go.sum
   cd "${TMP_DIR}"
-  GO111MODULE=on GOBIN="${TMP_DIR}" go get "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
+  GO111MODULE=on GOBIN="${TMP_DIR}" go install "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
   export PATH="${TMP_DIR}:${PATH}"
 fi
 


### PR DESCRIPTION
Squashed 'release-tools/' changes from 335339f0..e4dab7ff

[e4dab7ff](https://github.com/kubernetes-csi/csi-release-tools/commit/e4dab7ff) Merge [pull request #194](https://github.com/kubernetes-csi/csi-release-tools/pull/194) from yselkowitz/registry-k8s-io
[84a4d5a1](https://github.com/kubernetes-csi/csi-release-tools/commit/84a4d5a1) Move from k8s.gcr.io to registry.k8s.io
[37d11049](https://github.com/kubernetes-csi/csi-release-tools/commit/37d11049) Merge [pull request #191](https://github.com/kubernetes-csi/csi-release-tools/pull/191) from pohly/go-1.18
[db917f5c](https://github.com/kubernetes-csi/csi-release-tools/commit/db917f5c) update to Go 1.18

git-subtree-dir: release-tools
git-subtree-split: e4dab7ff57c24cf3e8d37cd3365636fddaff7e0a

```release-note
NONE
```