### PR TITLE
Use registry.k8s.io for deployment

### DIFF
--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccount: csi-resizer
       containers:
         - name: csi-resizer
-          image: gcr.io/k8s-staging-sig-storage/csi-resizer:canary
+          image: registry.k8s.io/k8s-staging-sig-storage/csi-resizer:canary
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
What type of PR is this?
/kind feature deprecation

What this PR does / why we need it:

Related to:
https://github.com/kubernetes-csi/external-snapshotter/pull/687
Switch to the new endpoint for container images. See: https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Special notes for your reviewer:
registry.k8s.io is currently a redirect to k8s.gcr.io. The change should be transparent to any pulling from k8s.gcr.io.

Does this PR introduce a user-facing change?:

NONE