### PR TITLE
Fix panic if unable to update PVC

### DIFF
--- a/pkg/controller/resize_status.go
+++ b/pkg/controller/resize_status.go
@@ -45,7 +45,7 @@ func (ctrl *resizeController) markControllerResizeInProgress(
 	newPVC.Status.AllocatedResources = v1.ResourceList{v1.ResourceStorage: newSize}
 	updatedPVC, err := ctrl.patchClaim(pvc, newPVC, true /* addResourceVersionCheck */)
 	if err != nil {
-		return nil, err
+		return pvc, err
 	}
 	return updatedPVC, nil
 }


### PR DESCRIPTION
This fixes a panic in code that assumes a PVC is returned even if update of PVC fails.


It only happens in path that runs recovery from expansion failure code.

```release-note
Fix panic in recovery path if marking pvc as resize in progress fails
```


