### PR TITLE
Add Groups to Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,29 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    golang-dependencies:
+      patterns:
+        - "github.com/golang*"
+        - "golang.org*"
+        - "google.golang.org*"
+    k8s-dependencies:
+      patterns:
+        - "k8s.io*"
+        - "sigs.k8s.io*"
+    github-dependencies:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "github.com/golang*"
+        - "golang.org*"
+        - "google.golang.org*"
+        - "k8s.io*"
+        - "sigs.k8s.io*"
   labels:
     - "area/dependency"
     - "release-note-none"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Add back groups and we can use [dependabot command like ignore](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-for-grouped-version-updates-with-comment-commands) to exclude packages.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```