### PR TITLE
Add Modify Volume Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Various external-resizer releases come with different alpha / beta features.
 
 The following table reflects the head of this branch.
 
-| Feature           | Status  | Default | Description                                                                                                                   |
-| ----------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| VolumeExpansion   | Beta    | On      | [Support for expanding CSI volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#csi-volume-expansion).    |
-| ReadWriteOncePod  | Alpha   | Off     | [Single pod access mode for PersistentVolumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes). |
+| Feature                | Status  | Default | Description                                                                                                                   |
+| ---------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| VolumeExpansion        | Beta    | On      | [Support for expanding CSI volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#csi-volume-expansion).    |
+| ReadWriteOncePod       | Alpha   | Off     | [Single pod access mode for PersistentVolumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes). |
+| VolumeAttributesClass  | Alpha   | Off     | [Volume Attributes Classes](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes).                           |
 
 ## Usage
 

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -42,6 +42,10 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  # only required if enabling the alpha volume modify feature
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/container-storage-interface/spec v1.9.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/kubernetes-csi/csi-lib-utils v0.17.0
@@ -37,7 +38,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -207,7 +207,7 @@ func TestController(t *testing.T) {
 			disableVolumeInUseErrorHandler: true,
 		},
 	} {
-		client := csi.NewMockClient("mock", test.NodeResize, true, true, true)
+		client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true)
 		driverName, _ := client.GetDriverName(context.TODO())
 
 		var expectedCap resource.Quantity
@@ -343,7 +343,7 @@ func TestResizePVC(t *testing.T) {
 			expectFailure:    true,
 		},
 	} {
-		client := csi.NewMockClient("mock", test.NodeResize, true, true, true)
+		client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true)
 		if test.expansionFailure {
 			client.SetExpansionFailed()
 		}

--- a/pkg/controller/expand_and_recover.go
+++ b/pkg/controller/expand_and_recover.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 
 	"github.com/kubernetes-csi/external-resizer/pkg/util"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
@@ -167,7 +165,7 @@ func (ctrl *resizeController) callResizeOnPlugin(
 		if inUseError(err) {
 			ctrl.usedPVCs.addPVCWithInUseError(pvc)
 		}
-		if isFinalError(err) {
+		if util.IsFinalError(err) {
 			var markExpansionFailedError error
 			pvc, markExpansionFailedError = ctrl.markControllerExpansionFailed(pvc)
 			if markExpansionFailedError != nil {
@@ -203,29 +201,5 @@ func (ctrl *resizeController) pvCanBeExpanded(pv *v1.PersistentVolume, pvc *v1.P
 		klog.V(4).InfoS("Persistent volume is not bound to PVC being updated", "PVC", klog.KObj(pvc))
 		return false
 	}
-	return true
-}
-
-func isFinalError(err error) bool {
-	// Sources:
-	// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
-	// https://github.com/container-storage-interface/spec/blob/master/spec.md
-	st, ok := status.FromError(err)
-	if !ok {
-		// This is not gRPC error. The operation must have failed before gRPC
-		// method was called, otherwise we would get gRPC error.
-		// We don't know if any previous volume operation is in progress, be on the safe side.
-		return false
-	}
-	switch st.Code() {
-	case codes.Canceled, // gRPC: Client Application cancelled the request
-		codes.DeadlineExceeded,  // gRPC: Timeout
-		codes.Unavailable,       // gRPC: Server shutting down, TCP connection broken - previous volume operation may be still in progress.
-		codes.ResourceExhausted, // gRPC: Server temporarily out of resources - previous volume operation may be still in progress.
-		codes.Aborted:           // CSI: Operation pending for volume
-		return false
-	}
-	// All other errors mean that operation either did not
-	// even start or failed. It is for sure not in progress.
 	return true
 }

--- a/pkg/controller/expand_and_recover_test.go
+++ b/pkg/controller/expand_and_recover_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/kubernetes-csi/external-resizer/pkg/csi"
 	"github.com/kubernetes-csi/external-resizer/pkg/features"
 	"github.com/kubernetes-csi/external-resizer/pkg/resizer"
+	"github.com/kubernetes-csi/external-resizer/pkg/testutil"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/util/workqueue"
@@ -32,7 +32,7 @@ func TestExpandAndRecover(t *testing.T) {
 	}{
 		{
 			name:                  "pvc.spec.size > pv.spec.size, resize_status=node_expansion_inprogress",
-			pvc:                   getTestPVC("test-vol0", "2G", "1G", "", ""),
+			pvc:                   testutil.GetTestPVC("test-vol0", "2G", "1G", "", ""),
 			pv:                    createPV(1, "claim01", defaultNS, "test-uid", &fsVolumeMode),
 			expectedResizeStatus:  v1.PersistentVolumeClaimNodeResizePending,
 			expectedAllocatedSize: resource.MustParse("2G"),
@@ -40,7 +40,7 @@ func TestExpandAndRecover(t *testing.T) {
 		},
 		{
 			name:                  "pvc.spec.size = pv.spec.size, resize_status=no_expansion_inprogress",
-			pvc:                   getTestPVC("test-vol0", "1G", "1G", "", ""),
+			pvc:                   testutil.GetTestPVC("test-vol0", "1G", "1G", "", ""),
 			pv:                    createPV(1, "claim01", defaultNS, "test-uid", &fsVolumeMode),
 			expectedResizeStatus:  v1.PersistentVolumeClaimNodeResizePending,
 			expectedAllocatedSize: resource.MustParse("1G"),
@@ -48,7 +48,7 @@ func TestExpandAndRecover(t *testing.T) {
 		},
 		{
 			name:                  "pvc.spec.size > pv.spec.size, resize_status=controller_expansion_failed",
-			pvc:                   getTestPVC("test-vol0", "5G" /*specSize*/, "3G" /*statusSize*/, "10G" /*allocatedSize*/, v1.PersistentVolumeClaimControllerResizeFailed),
+			pvc:                   testutil.GetTestPVC("test-vol0", "5G" /*specSize*/, "3G" /*statusSize*/, "10G" /*allocatedSize*/, v1.PersistentVolumeClaimControllerResizeFailed),
 			pv:                    createPV(3, "claim01", defaultNS, "test-uid", &fsVolumeMode),
 			expectedResizeStatus:  v1.PersistentVolumeClaimNodeResizePending,
 			expectedAllocatedSize: resource.MustParse("5G"),
@@ -56,7 +56,7 @@ func TestExpandAndRecover(t *testing.T) {
 		},
 		{
 			name:                       "pvc.spec.size = pv.spec.size, resize_status=node_expansion_failed, disable_controller_expansion=true",
-			pvc:                        getTestPVC("test-vol0", "5G" /*specSize*/, "3G" /*statusSize*/, "10G" /*allocatedSize*/, v1.PersistentVolumeClaimNodeResizeFailed),
+			pvc:                        testutil.GetTestPVC("test-vol0", "5G" /*specSize*/, "3G" /*statusSize*/, "10G" /*allocatedSize*/, v1.PersistentVolumeClaimNodeResizeFailed),
 			pv:                         createPV(10, "claim01", defaultNS, "test-uid", &fsVolumeMode),
 			disableControllerExpansion: true,
 			expectedResizeStatus:       v1.PersistentVolumeClaimNodeResizePending,
@@ -65,7 +65,7 @@ func TestExpandAndRecover(t *testing.T) {
 		},
 		{
 			name:                  "pvc.spec.size = pv.spec.size, resize_status=node_expansion_pending",
-			pvc:                   getTestPVC("test-vol0", "1G", "1G", "1G", v1.PersistentVolumeClaimNodeResizePending),
+			pvc:                   testutil.GetTestPVC("test-vol0", "1G", "1G", "1G", v1.PersistentVolumeClaimNodeResizePending),
 			pv:                    createPV(1, "claim01", defaultNS, "test-uid", &fsVolumeMode),
 			expectedResizeStatus:  v1.PersistentVolumeClaimNodeResizePending,
 			expectedAllocatedSize: resource.MustParse("1G"),
@@ -73,7 +73,7 @@ func TestExpandAndRecover(t *testing.T) {
 		},
 		{
 			name:                  "pvc.spec.size > pv.spec.size, disable_node_expansion=true, resize_status=no_expansion_inprogress",
-			pvc:                   getTestPVC("test-vol0", "2G", "1G", "", ""),
+			pvc:                   testutil.GetTestPVC("test-vol0", "2G", "1G", "", ""),
 			pv:                    createPV(1, "claim01", defaultNS, "test-uid", &fsVolumeMode),
 			disableNodeExpansion:  true,
 			expectedResizeStatus:  "",
@@ -82,7 +82,7 @@ func TestExpandAndRecover(t *testing.T) {
 		},
 		{
 			name:                  "pv.spec.size >= pvc.spec.size, resize_status=node_expansion_failed",
-			pvc:                   getTestPVC("test-vol0", "2G", "1G", "2G", v1.PersistentVolumeClaimNodeResizeFailed),
+			pvc:                   testutil.GetTestPVC("test-vol0", "2G", "1G", "2G", v1.PersistentVolumeClaimNodeResizeFailed),
 			pv:                    createPV(2, "claim01", defaultNS, "test-uid", &fsVolumeMode),
 			expectedResizeStatus:  v1.PersistentVolumeClaimNodeResizePending,
 			expectedAllocatedSize: resource.MustParse("2G"),
@@ -90,7 +90,7 @@ func TestExpandAndRecover(t *testing.T) {
 		},
 		{
 			name:                  "pvc.spec.size > pv.spec.size, resize_status-node_expansion_pending",
-			pvc:                   getTestPVC("test-vol0", "10G", "1G", "3G", v1.PersistentVolumeClaimNodeResizePending),
+			pvc:                   testutil.GetTestPVC("test-vol0", "10G", "1G", "3G", v1.PersistentVolumeClaimNodeResizePending),
 			pv:                    createPV(3, "claim01", defaultNS, "test-uid", &fsVolumeMode),
 			expectedResizeStatus:  v1.PersistentVolumeClaimNodeResizePending,
 			expectedAllocatedSize: resource.MustParse("3G"),
@@ -98,7 +98,7 @@ func TestExpandAndRecover(t *testing.T) {
 		},
 		{
 			name:                  "pvc.spec.size > pv.spec.size, resize_status-node_expansion_inprogress",
-			pvc:                   getTestPVC("test-vol0", "10G", "1G", "3G", v1.PersistentVolumeClaimNodeResizeInProgress),
+			pvc:                   testutil.GetTestPVC("test-vol0", "10G", "1G", "3G", v1.PersistentVolumeClaimNodeResizeInProgress),
 			pv:                    createPV(3, "claim01", defaultNS, "test-uid", &fsVolumeMode),
 			expectedResizeStatus:  v1.PersistentVolumeClaimNodeResizeInProgress,
 			expectedAllocatedSize: resource.MustParse("3G"),
@@ -109,7 +109,7 @@ func TestExpandAndRecover(t *testing.T) {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, true)()
-			client := csi.NewMockClient("foo", !test.disableNodeExpansion, !test.disableControllerExpansion, true, true)
+			client := csi.NewMockClient("foo", !test.disableNodeExpansion, !test.disableControllerExpansion, false, true, true)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			var initialObjects []runtime.Object
@@ -150,34 +150,4 @@ func TestExpandAndRecover(t *testing.T) {
 
 		})
 	}
-}
-
-func getTestPVC(volumeName string, specSize, statusSize, allocatedSize string, resizeStatus v1.ClaimResourceStatus) *v1.PersistentVolumeClaim {
-	pvc := &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "claim01",
-			Namespace: defaultNS,
-			UID:       "test-uid",
-		},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-			Resources:   v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse(specSize)}},
-			VolumeName:  volumeName,
-		},
-		Status: v1.PersistentVolumeClaimStatus{
-			Phase: v1.ClaimBound,
-		},
-	}
-	if len(statusSize) > 0 {
-		pvc.Status.Capacity = v1.ResourceList{v1.ResourceStorage: resource.MustParse(statusSize)}
-	}
-	if len(allocatedSize) > 0 {
-		pvc.Status.AllocatedResources = v1.ResourceList{v1.ResourceStorage: resource.MustParse(allocatedSize)}
-	}
-	if len(resizeStatus) > 0 {
-		pvc.Status.AllocatedResourceStatuses = map[v1.ResourceName]v1.ClaimResourceStatus{
-			v1.ResourceStorage: resizeStatus,
-		}
-	}
-	return pvc
 }

--- a/pkg/controller/resize_status_test.go
+++ b/pkg/controller/resize_status_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/kubernetes-csi/external-resizer/pkg/csi"
 	"github.com/kubernetes-csi/external-resizer/pkg/features"
 	"github.com/kubernetes-csi/external-resizer/pkg/resizer"
+	"github.com/kubernetes-csi/external-resizer/pkg/testutil"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/util/workqueue"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestResizeFunctions(t *testing.T) {
-	basePVC := makePVC([]v1.PersistentVolumeClaimCondition{})
+	basePVC := testutil.MakePVC([]v1.PersistentVolumeClaimCondition{})
 
 	tests := []struct {
 		name        string
@@ -29,43 +29,43 @@ func TestResizeFunctions(t *testing.T) {
 	}{
 		{
 			name:        "mark fs resize, with no other conditions",
-			pvc:         basePVC.get(),
-			expectedPVC: basePVC.withStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).get(),
+			pvc:         basePVC.Get(),
+			expectedPVC: basePVC.WithStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, size resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markForPendingNodeExpansion(pvc)
 			},
 		},
 		{
 			name: "mark fs resize, when other resource statuses are present",
-			pvc:  basePVC.withResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeFailed).get(),
-			expectedPVC: basePVC.withResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeFailed).
-				withStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).get(),
+			pvc:  basePVC.WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeFailed).Get(),
+			expectedPVC: basePVC.WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeFailed).
+				WithStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, _ resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markForPendingNodeExpansion(pvc)
 			},
 		},
 		{
 			name:        "mark controller resize in-progress",
-			pvc:         basePVC.get(),
-			expectedPVC: basePVC.withStorageResourceStatus(v1.PersistentVolumeClaimControllerResizeInProgress).get(),
+			pvc:         basePVC.Get(),
+			expectedPVC: basePVC.WithStorageResourceStatus(v1.PersistentVolumeClaimControllerResizeInProgress).Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, q resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markControllerResizeInProgress(pvc, q)
 			},
 		},
 		{
 			name:        "mark controller resize failed",
-			pvc:         basePVC.get(),
-			expectedPVC: basePVC.withStorageResourceStatus(v1.PersistentVolumeClaimControllerResizeFailed).get(),
+			pvc:         basePVC.Get(),
+			expectedPVC: basePVC.WithStorageResourceStatus(v1.PersistentVolumeClaimControllerResizeFailed).Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, q resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markControllerExpansionFailed(pvc)
 			},
 		},
 		{
 			name: "mark resize finished",
-			pvc: basePVC.withResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeFailed).
-				withStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).get(),
-			expectedPVC: basePVC.withResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeFailed).
-				withStorageResourceStatus("").get(),
+			pvc: basePVC.WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeFailed).
+				WithStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).Get(),
+			expectedPVC: basePVC.WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeFailed).
+				WithStorageResourceStatus("").Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, q resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markOverallExpansionAsFinished(pvc, q)
 			},
@@ -76,7 +76,7 @@ func TestResizeFunctions(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, true)()
-			client := csi.NewMockClient("foo", true, true, true, true)
+			client := csi.NewMockClient("foo", true, true, false, true, true)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			pvc := test.pvc
@@ -110,56 +110,4 @@ func TestResizeFunctions(t *testing.T) {
 		})
 	}
 
-}
-
-type pvcModifier struct {
-	pvc *v1.PersistentVolumeClaim
-}
-
-func (m pvcModifier) get() *v1.PersistentVolumeClaim {
-	return m.pvc.DeepCopy()
-}
-
-func makePVC(conditions []v1.PersistentVolumeClaimCondition) pvcModifier {
-	pvc := &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "resize"},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes: []v1.PersistentVolumeAccessMode{
-				v1.ReadWriteOnce,
-				v1.ReadOnlyMany,
-			},
-			Resources: v1.VolumeResourceRequirements{
-				Requests: v1.ResourceList{
-					v1.ResourceName(v1.ResourceStorage): resource.MustParse("2Gi"),
-				},
-			},
-		},
-		Status: v1.PersistentVolumeClaimStatus{
-			Phase:      v1.ClaimBound,
-			Conditions: conditions,
-			Capacity: v1.ResourceList{
-				v1.ResourceStorage: resource.MustParse("2Gi"),
-			},
-		},
-	}
-	return pvcModifier{pvc}
-}
-
-func (m pvcModifier) withStorageResourceStatus(status v1.ClaimResourceStatus) pvcModifier {
-	return m.withResourceStatus(v1.ResourceStorage, status)
-}
-
-func (m pvcModifier) withResourceStatus(resource v1.ResourceName, status v1.ClaimResourceStatus) pvcModifier {
-	if m.pvc.Status.AllocatedResourceStatuses != nil && status == "" {
-		delete(m.pvc.Status.AllocatedResourceStatuses, resource)
-		return m
-	}
-	if m.pvc.Status.AllocatedResourceStatuses != nil {
-		m.pvc.Status.AllocatedResourceStatuses[resource] = status
-	} else {
-		m.pvc.Status.AllocatedResourceStatuses = map[v1.ResourceName]v1.ClaimResourceStatus{
-			resource: status,
-		}
-	}
-	return m
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -31,6 +31,13 @@ const (
 	//
 	// Allows users to recover from volume expansion failures
 	RecoverVolumeExpansionFailure featuregate.Feature = "RecoverVolumeExpansionFailure"
+
+	// owner: @sunnylovestiramisu
+	// kep: https://kep.k8s.io/3751
+	// alpha: v1.29
+	//
+	// Pass VolumeAttributesClass parameters to supporting CSI drivers during ModifyVolume
+	VolumeAttributesClass featuregate.Feature = "VolumeAttributesClass"
 )
 
 func init() {
@@ -40,4 +47,5 @@ func init() {
 var defaultResizerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AnnotateFsResize:              {Default: false, PreRelease: featuregate.Alpha},
 	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
+	VolumeAttributesClass:         {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/modifier/csi_modifier.go
+++ b/pkg/modifier/csi_modifier.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kubernetes-csi/external-resizer/pkg/csi"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+)
+
+func NewModifierFromClient(
+	csiClient csi.Client,
+	timeout time.Duration,
+	k8sClient kubernetes.Interface,
+	informerFactory informers.SharedInformerFactory,
+	driverName string) (Modifier, error) {
+
+	_, err := supportsControllerModify(csiClient, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if plugin supports controller modify: %v", err)
+	}
+
+	return &csiModifier{
+		name:    driverName,
+		client:  csiClient,
+		timeout: timeout,
+
+		k8sClient: k8sClient,
+	}, nil
+}
+
+type csiModifier struct {
+	name    string
+	client  csi.Client
+	timeout time.Duration
+
+	k8sClient kubernetes.Interface
+}
+
+func (r *csiModifier) Name() string {
+	return r.name
+}
+
+func (r *csiModifier) Modify(pv *v1.PersistentVolume, mutableParameters map[string]string) error {
+
+	var volumeID string
+	var source *v1.CSIPersistentVolumeSource
+
+	if pv.Spec.CSI != nil {
+		// handle CSI volume
+		source = pv.Spec.CSI
+		volumeID = source.VolumeHandle
+	} else {
+		return fmt.Errorf("volume %v is not a CSI volumes, modify volume feature only supports CSI volumes", pv.Name)
+	}
+
+	if len(volumeID) == 0 {
+		return errors.New("empty volume handle")
+	}
+
+	var secrets map[string]string
+
+	ctx, cancel := timeoutCtx(r.timeout)
+
+	defer cancel()
+	err := r.client.Modify(ctx, volumeID, secrets, mutableParameters)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func supportsControllerModify(client csi.Client, timeout time.Duration) (bool, error) {
+	ctx, cancel := timeoutCtx(timeout)
+	defer cancel()
+	return client.SupportsControllerModify(ctx)
+}
+
+func timeoutCtx(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}

--- a/pkg/modifier/csi_modifier_test.go
+++ b/pkg/modifier/csi_modifier_test.go
@@ -1,0 +1,45 @@
+package modifier
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubernetes-csi/external-resizer/pkg/csi"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	controllerServiceNotSupportErr = errors.New("CSI driver does not support controller service")
+)
+
+func TestNewModifier(t *testing.T) {
+	for i, c := range []struct {
+		SupportsControllerModify bool
+		Error                    error
+	}{
+		// Create succeeded.
+		{
+			SupportsControllerModify: true,
+		},
+		// Controller modify not supported.
+		{
+			SupportsControllerModify: false,
+		},
+	} {
+		client := csi.NewMockClient("mock", false, false, c.SupportsControllerModify, false, false)
+		driverName := "mock-driver"
+		k8sClient, informerFactory := fakeK8s()
+		_, err := NewModifierFromClient(client, 0, k8sClient, informerFactory, driverName)
+		if err != c.Error {
+			t.Errorf("Case %d: Unexpected error: wanted %v, got %v", i, c.Error, err)
+		}
+	}
+}
+
+func fakeK8s() (kubernetes.Interface, informers.SharedInformerFactory) {
+	client := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	return client, informerFactory
+}

--- a/pkg/modifier/modifier.go
+++ b/pkg/modifier/modifier.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifier
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// Modifier is responsible for handling pvc modify volume requests.
+type Modifier interface {
+	// Name returns the modifier's name.
+	Name() string
+	// Modify executes the modify operation of this PVC.
+	Modify(pv *v1.PersistentVolume, mutableParameters map[string]string) error
+}

--- a/pkg/modifycontroller/controller.go
+++ b/pkg/modifycontroller/controller.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifycontroller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kubernetes-csi/external-resizer/pkg/util"
+
+	"github.com/kubernetes-csi/external-resizer/pkg/modifier"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	storagev1alpha1listers "k8s.io/client-go/listers/storage/v1alpha1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+// ModifyController watches PVCs and checks if they are requesting an modify operation.
+// If requested, it will modify the volume according to parameters in VolumeAttributesClass
+type ModifyController interface {
+	// Run starts the controller.
+	Run(workers int, ctx context.Context)
+}
+
+type modifyController struct {
+	name            string
+	modifier        modifier.Modifier
+	kubeClient      kubernetes.Interface
+	claimQueue      workqueue.RateLimitingInterface
+	eventRecorder   record.EventRecorder
+	pvLister        corelisters.PersistentVolumeLister
+	pvListerSynced  cache.InformerSynced
+	pvcLister       corelisters.PersistentVolumeClaimLister
+	pvcListerSynced cache.InformerSynced
+	vacLister       storagev1alpha1listers.VolumeAttributesClassLister
+	vacListerSynced cache.InformerSynced
+	// the key of the map is {PVC_NAMESPACE}/{PVC_NAME}
+	uncertainPVCs map[string]v1.PersistentVolumeClaim
+}
+
+// NewModifyController returns a ModifyController.
+func NewModifyController(
+	name string,
+	modifier modifier.Modifier,
+	kubeClient kubernetes.Interface,
+	resyncPeriod time.Duration,
+	informerFactory informers.SharedInformerFactory,
+	pvcRateLimiter workqueue.RateLimiter) ModifyController {
+	pvInformer := informerFactory.Core().V1().PersistentVolumes()
+	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
+	vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events(v1.NamespaceAll)})
+	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme,
+		v1.EventSource{Component: fmt.Sprintf("external-resizer %s", name)})
+
+	claimQueue := workqueue.NewNamedRateLimitingQueue(
+		pvcRateLimiter, fmt.Sprintf("%s-pvc", name))
+
+	ctrl := &modifyController{
+		name:            name,
+		modifier:        modifier,
+		kubeClient:      kubeClient,
+		pvListerSynced:  pvInformer.Informer().HasSynced,
+		pvLister:        pvInformer.Lister(),
+		pvcListerSynced: pvcInformer.Informer().HasSynced,
+		pvcLister:       pvcInformer.Lister(),
+		vacListerSynced: vacInformer.Informer().HasSynced,
+		vacLister:       vacInformer.Lister(),
+		claimQueue:      claimQueue,
+		eventRecorder:   eventRecorder,
+	}
+
+	// Add a resync period as the PVC's request modify can be modified again when we handling
+	// a previous modify request of the same PVC.
+	pvcInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+		AddFunc:    ctrl.addPVC,
+		UpdateFunc: ctrl.updatePVC,
+		DeleteFunc: ctrl.deletePVC,
+	}, resyncPeriod)
+
+	// Add a resync period as the VAC can be created after a PVC is created
+	// VAC is immutable
+	vacInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{}, resyncPeriod)
+
+	return ctrl
+}
+
+func (ctrl *modifyController) initUncertainPVCs() error {
+	ctrl.uncertainPVCs = make(map[string]v1.PersistentVolumeClaim)
+	allPVCs, err := ctrl.pvcLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list pvcs when init uncertain pvcs: %v", err)
+		return err
+	}
+	for _, pvc := range allPVCs {
+		if pvc.Status.ModifyVolumeStatus != nil && (pvc.Status.ModifyVolumeStatus.Status == v1.PersistentVolumeClaimModifyVolumeInProgress || pvc.Status.ModifyVolumeStatus.Status == v1.PersistentVolumeClaimModifyVolumeInfeasible) {
+			pvcKey, err := cache.MetaNamespaceKeyFunc(pvc)
+			if err != nil {
+				return err
+			}
+			ctrl.uncertainPVCs[pvcKey] = *pvc.DeepCopy()
+		}
+	}
+
+	return nil
+}
+
+func (ctrl *modifyController) addPVC(obj interface{}) {
+	objKey, err := util.GetObjectKey(obj)
+	if err != nil {
+		return
+	}
+	ctrl.claimQueue.Add(objKey)
+}
+
+func (ctrl *modifyController) updatePVC(oldObj, newObj interface{}) {
+	oldPVC, ok := oldObj.(*v1.PersistentVolumeClaim)
+	if !ok || oldPVC == nil {
+		return
+	}
+
+	newPVC, ok := newObj.(*v1.PersistentVolumeClaim)
+	if !ok || newPVC == nil {
+		return
+	}
+
+	// Only trigger modify volume if the following conditions are met
+	// 1. Non empty vac name
+	// 2. oldVacName != newVacName
+	// 3. PVC is in Bound state
+	oldVacName := oldPVC.Spec.VolumeAttributesClassName
+	newVacName := newPVC.Spec.VolumeAttributesClassName
+	if newVacName != nil && *newVacName != "" && (*newVacName != *oldVacName || oldVacName == nil) && oldPVC.Status.Phase == v1.ClaimBound {
+		_, err := ctrl.pvLister.Get(oldPVC.Spec.VolumeName)
+		if err != nil {
+			klog.Errorf("Get PV %q of pvc %q in PVInformer cache failed: %v", oldPVC.Spec.VolumeName, klog.KObj(oldPVC), err)
+			return
+		}
+		// Handle modify volume by adding to the claimQueue to avoid race conditions
+		ctrl.addPVC(newObj)
+	} else {
+		klog.V(4).InfoS("No need to modify PVC", "PVC", klog.KObj(newPVC))
+	}
+}
+
+func (ctrl *modifyController) deletePVC(obj interface{}) {
+	objKey, err := util.GetObjectKey(obj)
+	if err != nil {
+		return
+	}
+	ctrl.claimQueue.Forget(objKey)
+}
+
+// modifyPVC modifies the PVC and PV based on VAC
+func (ctrl *modifyController) modifyPVC(pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) error {
+	var err error
+	if isFirstTimeModifyVolumeWithPVC(pvc, pv) {
+		// If it is first time adding a vac, always validate and then call modify volume
+		_, _, err, _ = ctrl.validateVACAndModifyVolumeWithTarget(pvc, pv)
+	} else {
+		_, _, err, _ = ctrl.modify(pvc, pv)
+	}
+	return err
+}
+
+func isFirstTimeModifyVolumeWithPVC(pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) bool {
+	if pv.Spec.VolumeAttributesClassName == nil && pvc.Spec.VolumeAttributesClassName != nil {
+		return true
+	}
+	return false
+}
+
+// Run starts the controller.
+func (ctrl *modifyController) Run(
+	workers int, ctx context.Context) {
+	defer ctrl.claimQueue.ShutDown()
+
+	klog.InfoS("Starting external resizer for modify volume", "controller", ctrl.name)
+	defer klog.InfoS("Shutting down external resizer", "controller", ctrl.name)
+
+	stopCh := ctx.Done()
+	informersSyncd := []cache.InformerSynced{ctrl.pvListerSynced, ctrl.pvcListerSynced}
+	informersSyncd = append(informersSyncd, ctrl.vacListerSynced)
+
+	if !cache.WaitForCacheSync(stopCh, informersSyncd...) {
+		klog.ErrorS(nil, "Cannot sync pod, pv, pvc or vac caches")
+		return
+	}
+
+	// Cache all the InProgress/Infeasible PVCs as Uncertain for ModifyVolume
+	err := ctrl.initUncertainPVCs()
+	if err != nil {
+		klog.ErrorS(err, "Failed to initialize uncertain pvcs")
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(ctrl.sync, 0, stopCh)
+	}
+
+	<-stopCh
+}
+
+// sync is the main worker to sync PVCs.
+func (ctrl *modifyController) sync() {
+	key, quit := ctrl.claimQueue.Get()
+	if quit {
+		return
+	}
+	defer ctrl.claimQueue.Done(key)
+
+	if err := ctrl.syncPVC(key.(string)); err != nil {
+		// Put PVC back to the queue so that we can retry later.
+		klog.ErrorS(err, "Error syncing PVC")
+		ctrl.claimQueue.AddRateLimited(key)
+	} else {
+		ctrl.claimQueue.Forget(key)
+	}
+}
+
+// syncPVC checks if a pvc requests resizing, and execute the resize operation if requested.
+func (ctrl *modifyController) syncPVC(key string) error {
+	klog.V(4).InfoS("Started PVC processing for modify controller", "key", key)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("getting namespace and name from key %s failed: %v", key, err)
+	}
+
+	pvc, err := ctrl.pvcLister.PersistentVolumeClaims(namespace).Get(name)
+	if err != nil {
+		return fmt.Errorf("getting PVC %s/%s failed: %v", namespace, name, err)
+	}
+
+	if pvc.Spec.VolumeName == "" {
+		klog.V(4).InfoS("PV bound to PVC is not created yet", "PVC", klog.KObj(pvc))
+		return nil
+	}
+
+	pv, err := ctrl.pvLister.Get(pvc.Spec.VolumeName)
+	if err != nil {
+		return fmt.Errorf("Get PV %q of pvc %q in PVInformer cache failed: %v", pvc.Spec.VolumeName, klog.KObj(pvc), err)
+	}
+
+	// Only trigger modify volume if the following conditions are met
+	// 1. Non empty vac name
+	// 2. PVC is in Bound state
+	vacName := pvc.Spec.VolumeAttributesClassName
+	if vacName != nil && *vacName != "" && pvc.Status.Phase == v1.ClaimBound {
+		_, _, err, _ := ctrl.modify(pvc, pv)
+		if err != nil {
+			return err
+		}
+	} else {
+		klog.V(4).InfoS("No need to modify PV", "PV", klog.KObj(pv))
+	}
+
+	return nil
+}

--- a/pkg/modifycontroller/controller_test.go
+++ b/pkg/modifycontroller/controller_test.go
@@ -1,0 +1,230 @@
+package modifycontroller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-csi/external-resizer/pkg/features"
+
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/kubernetes-csi/external-resizer/pkg/csi"
+	"github.com/kubernetes-csi/external-resizer/pkg/modifier"
+
+	v1 "k8s.io/api/core/v1"
+	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+func TestController(t *testing.T) {
+	basePVC := createTestPVC(pvcName, testVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/)
+	basePV := createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, testVac)
+	firstTimePV := basePV.DeepCopy()
+	firstTimePV.Spec.VolumeAttributesClassName = nil
+	firstTimePVC := basePVC.DeepCopy()
+	firstTimePVC.Status.CurrentVolumeAttributesClassName = nil
+	firstTimePVC.Status.ModifyVolumeStatus = nil
+
+	tests := []struct {
+		name          string
+		pvc           *v1.PersistentVolumeClaim
+		pv            *v1.PersistentVolume
+		vacExists     bool
+		callCSIModify bool
+	}{
+		{
+			name:          "Modify called",
+			pvc:           createTestPVC(pvcName, "target-vac" /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
+			pv:            basePV,
+			vacExists:     true,
+			callCSIModify: true,
+		},
+		{
+			name:          "Nothing to modify",
+			pvc:           basePVC,
+			pv:            basePV,
+			vacExists:     true,
+			callCSIModify: false,
+		},
+		{
+			name:          "First time modify",
+			pvc:           firstTimePVC,
+			pv:            firstTimePV,
+			vacExists:     true,
+			callCSIModify: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Setup
+			client := csi.NewMockClient("foo", true, true, true, true, true)
+			driverName, _ := client.GetDriverName(context.TODO())
+
+			var initialObjects []runtime.Object
+			initialObjects = append(initialObjects, test.pvc)
+			initialObjects = append(initialObjects, test.pv)
+			// existing vac set in the pvc and pv
+			initialObjects = append(initialObjects, testVacObject)
+			if test.vacExists {
+				initialObjects = append(initialObjects, targetVacObject)
+			}
+
+			kubeClient, informerFactory := fakeK8s(initialObjects)
+			pvInformer := informerFactory.Core().V1().PersistentVolumes()
+			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
+			vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			if err != nil {
+				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
+			}
+
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)()
+			controller := NewModifyController(driverName,
+				csiModifier, kubeClient,
+				time.Second, informerFactory,
+				workqueue.DefaultControllerRateLimiter())
+
+			ctrlInstance, _ := controller.(*modifyController)
+
+			stopCh := make(chan struct{})
+			informerFactory.Start(stopCh)
+
+			ctx := context.TODO()
+			defer ctx.Done()
+			go controller.Run(1, ctx)
+
+			for _, obj := range initialObjects {
+				switch obj.(type) {
+				case *v1.PersistentVolume:
+					pvInformer.Informer().GetStore().Add(obj)
+				case *v1.PersistentVolumeClaim:
+					pvcInformer.Informer().GetStore().Add(obj)
+				case *storagev1alpha1.VolumeAttributesClass:
+					vacInformer.Informer().GetStore().Add(obj)
+				default:
+					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)
+				}
+			}
+			time.Sleep(time.Second * 2)
+			err = ctrlInstance.modifyPVC(test.pvc, test.pv)
+
+			modifyCallCount := client.GetModifyCount()
+			if test.callCSIModify && modifyCallCount == 0 {
+				t.Fatalf("for %s: expected csi modify call, no csi modify call was made", test.name)
+			}
+
+			if !test.callCSIModify && modifyCallCount > 0 {
+				t.Fatalf("for %s: expected no csi modify call, received csi modify request", test.name)
+			}
+		})
+	}
+
+}
+
+func TestModifyPVC(t *testing.T) {
+	basePV := createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, testVac)
+
+	tests := []struct {
+		name          string
+		pvc           *v1.PersistentVolumeClaim
+		pv            *v1.PersistentVolume
+		modifyFailure bool
+		expectFailure bool
+	}{
+		{
+			name:          "Modify succeeded",
+			pvc:           createTestPVC(pvcName, "target-vac" /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
+			pv:            basePV,
+			modifyFailure: false,
+			expectFailure: false,
+		},
+		{
+			name:          "Modify failed",
+			pvc:           createTestPVC(pvcName, "target-vac" /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
+			pv:            basePV,
+			modifyFailure: true,
+			expectFailure: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := csi.NewMockClient("mock", true, true, true, true, true)
+			if test.modifyFailure {
+				client.SetModifyFailed()
+			}
+			driverName, _ := client.GetDriverName(context.TODO())
+
+			initialObjects := []runtime.Object{}
+			if test.pvc != nil {
+				initialObjects = append(initialObjects, test.pvc)
+			}
+			if test.pv != nil {
+				test.pv.Spec.PersistentVolumeSource.CSI.Driver = driverName
+				initialObjects = append(initialObjects, test.pv)
+			}
+
+			// existing vac set in the pvc and pv
+			initialObjects = append(initialObjects, testVacObject)
+			// new vac used in modify volume
+			initialObjects = append(initialObjects, targetVacObject)
+
+			kubeClient, informerFactory := fakeK8s(initialObjects)
+			pvInformer := informerFactory.Core().V1().PersistentVolumes()
+			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
+			vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			if err != nil {
+				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
+			}
+
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)()
+			controller := NewModifyController(driverName,
+				csiModifier, kubeClient,
+				time.Second, informerFactory,
+				workqueue.DefaultControllerRateLimiter())
+
+			ctrlInstance, _ := controller.(*modifyController)
+
+			stopCh := make(chan struct{})
+			informerFactory.Start(stopCh)
+
+			ctx := context.TODO()
+			defer ctx.Done()
+			go controller.Run(1, ctx)
+
+			for _, obj := range initialObjects {
+				switch obj.(type) {
+				case *v1.PersistentVolume:
+					pvInformer.Informer().GetStore().Add(obj)
+				case *v1.PersistentVolumeClaim:
+					pvcInformer.Informer().GetStore().Add(obj)
+				case *storagev1alpha1.VolumeAttributesClass:
+					vacInformer.Informer().GetStore().Add(obj)
+				default:
+					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)
+				}
+			}
+
+			time.Sleep(time.Second * 2)
+
+			_, _, err, _ = ctrlInstance.modify(test.pvc, test.pv)
+
+			if test.expectFailure && err == nil {
+				t.Errorf("for %s expected error got nothing", test.name)
+			}
+
+			if !test.expectFailure {
+				if err != nil {
+					t.Errorf("for %s, unexpected error: %v", test.name, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/modifycontroller/modify_status.go
+++ b/pkg/modifycontroller/modify_status.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifycontroller
+
+import (
+	"fmt"
+
+	"github.com/kubernetes-csi/external-resizer/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// markControllerModifyVolumeStatus will mark ModifyVolumeStatus other than completed in the PVC
+func (ctrl *modifyController) markControllerModifyVolumeStatus(
+	pvc *v1.PersistentVolumeClaim,
+	modifyVolumeStatus v1.PersistentVolumeClaimModifyVolumeStatus,
+	err error) (*v1.PersistentVolumeClaim, error) {
+
+	newPVC := pvc.DeepCopy()
+	if newPVC.Status.ModifyVolumeStatus == nil {
+		newPVC.Status.ModifyVolumeStatus = &v1.ModifyVolumeStatus{}
+	}
+	newPVC.Status.ModifyVolumeStatus.Status = modifyVolumeStatus
+	// Update PVC's Condition to indicate modification
+	pvcCondition := v1.PersistentVolumeClaimCondition{
+		Type:               v1.PersistentVolumeClaimVolumeModifyingVolume,
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+	}
+	conditionMessage := ""
+	switch modifyVolumeStatus {
+	case v1.PersistentVolumeClaimModifyVolumeInProgress:
+		conditionMessage = "ModifyVolume operation in progress."
+		newPVC.Status.ModifyVolumeStatus.TargetVolumeAttributesClassName = *pvc.Spec.VolumeAttributesClassName
+	case v1.PersistentVolumeClaimModifyVolumeInfeasible:
+		conditionMessage = "ModifyVolume failed with error" + err.Error() + ". Waiting for retry."
+	}
+	pvcCondition.Message = conditionMessage
+	// Do not change conditions for pending modifications and keep existing conditions
+	if modifyVolumeStatus != v1.PersistentVolumeClaimModifyVolumePending {
+		newPVC.Status.Conditions = util.MergeModifyVolumeConditionsOfPVC(newPVC.Status.Conditions,
+			[]v1.PersistentVolumeClaimCondition{pvcCondition})
+	}
+
+	updatedPVC, err := util.PatchClaim(ctrl.kubeClient, pvc, newPVC, true)
+	if err != nil {
+		return pvc, fmt.Errorf("mark PVC %q as modify volume failed, errored with: %v", pvc.Name, err)
+	}
+	// Remove this PVC from the uncertain cache since the status is known now
+	if modifyVolumeStatus == v1.PersistentVolumeClaimModifyVolumeInfeasible {
+		ctrl.removePVCFromModifyVolumeUncertainCache(pvc)
+	}
+	return updatedPVC, nil
+}
+
+func (ctrl *modifyController) updateConditionBasedOnError(pvc *v1.PersistentVolumeClaim, err error) (*v1.PersistentVolumeClaim, error) {
+	newPVC := pvc.DeepCopy()
+	pvcCondition := v1.PersistentVolumeClaimCondition{
+		Type:               v1.PersistentVolumeClaimVolumeModifyVolumeError,
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Message:            "ModifyVolume failed with error. Waiting for retry.",
+	}
+
+	if err != nil {
+		pvcCondition.Message = "ModifyVolume failed with error: " + err.Error() + ". Waiting for retry."
+	}
+
+	newPVC.Status.Conditions = util.MergeModifyVolumeConditionsOfPVC(newPVC.Status.Conditions,
+		[]v1.PersistentVolumeClaimCondition{pvcCondition})
+
+	updatedPVC, err := util.PatchClaim(ctrl.kubeClient, pvc, newPVC, false)
+	if err != nil {
+		return pvc, fmt.Errorf("mark PVC %q as controller expansion failed, errored with: %v", pvc.Name, err)
+	}
+	return updatedPVC, nil
+}
+
+// markControllerModifyVolumeStatus will mark ModifyVolumeStatus as completed in the PVC
+// and update CurrentVolumeAttributesClassName, clear the conditions
+func (ctrl *modifyController) markControllerModifyVolumeCompleted(pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
+	// Update PVC
+	newPVC := pvc.DeepCopy()
+	// Update ModifyVolumeStatus to completed
+	var controllerModifyVolumeCompleted v1.PersistentVolumeClaimModifyVolumeStatus
+	if newPVC.Status.ModifyVolumeStatus == nil {
+		newPVC.Status.ModifyVolumeStatus = &v1.ModifyVolumeStatus{}
+	}
+	newPVC.Status.ModifyVolumeStatus.Status = controllerModifyVolumeCompleted
+
+	// Update CurrentVolumeAttributesClassName
+	newPVC.Status.CurrentVolumeAttributesClassName = &newPVC.Status.ModifyVolumeStatus.TargetVolumeAttributesClassName
+
+	// Clear all the conditions
+	newPVC.Status.Conditions = clearModifyVolumeConditions(newPVC.Status.Conditions)
+
+	// Update PV
+	newPV := pv.DeepCopy()
+	newPV.Spec.VolumeAttributesClassName = &newPVC.Status.ModifyVolumeStatus.TargetVolumeAttributesClassName
+
+	// Update PV before PVC to avoid PV not getting updated but PVC did
+	updatedPV, err := util.PatchPersistentVolume(ctrl.kubeClient, pv, newPV)
+	if err != nil {
+		return pvc, pv, fmt.Errorf("update pv.Spec.VolumeAttributesClassName for PVC %q failed, errored with: %v", pvc.Name, err)
+	}
+	updatedPVC, err := util.PatchClaim(ctrl.kubeClient, pvc, newPVC, false)
+
+	if err != nil {
+		return pvc, pv, fmt.Errorf("mark PVC %q as ModifyVolumeCompleted failed, errored with: %v", pvc.Name, err)
+	}
+
+	return updatedPVC, updatedPV, nil
+}
+
+// markControllerModifyVolumeStatus clears all the conditions related to modify volume and only
+// leave other condition types
+func clearModifyVolumeConditions(conditions []v1.PersistentVolumeClaimCondition) []v1.PersistentVolumeClaimCondition {
+	knownConditions := []v1.PersistentVolumeClaimCondition{}
+	for _, value := range conditions {
+		// Only keep conditions that are not related to modify volume
+		if value.Type != v1.PersistentVolumeClaimVolumeModifyVolumeError && value.Type != v1.PersistentVolumeClaimVolumeModifyingVolume {
+			knownConditions = append(knownConditions, value)
+		}
+	}
+	return knownConditions
+}
+
+// removePVCFromModifyVolumeUncertainCache removes the pvc from the uncertain cache
+func (ctrl *modifyController) removePVCFromModifyVolumeUncertainCache(pvc *v1.PersistentVolumeClaim) error {
+	if ctrl.uncertainPVCs == nil {
+		return nil
+	}
+	// Format of the key of the uncertainPVCs is NAMESPACE/NAME of the pvc
+	pvcKey, err := cache.MetaNamespaceKeyFunc(pvc)
+	if err != nil {
+		return err
+	}
+	_, ok := ctrl.uncertainPVCs[pvcKey]
+	if ok {
+		delete(ctrl.uncertainPVCs, pvcKey)
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -1,0 +1,406 @@
+package modifycontroller
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubernetes-csi/external-resizer/pkg/csi"
+	"github.com/kubernetes-csi/external-resizer/pkg/features"
+	"github.com/kubernetes-csi/external-resizer/pkg/modifier"
+	"github.com/kubernetes-csi/external-resizer/pkg/testutil"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+const (
+	pvcName      = "foo"
+	pvcNamespace = "modify"
+)
+
+var (
+	fsVolumeMode           = v1.PersistentVolumeFilesystem
+	testVac                = "test-vac"
+	targetVac              = "target-vac"
+	infeasibleErr          = status.Errorf(codes.InvalidArgument, "Parameters in VolumeAttributesClass is invalid")
+	finalErr               = status.Errorf(codes.Internal, "Final error")
+	pvcConditionInProgress = v1.PersistentVolumeClaimCondition{
+		Type:    v1.PersistentVolumeClaimVolumeModifyingVolume,
+		Status:  v1.ConditionTrue,
+		Message: "ModifyVolume operation in progress.",
+	}
+
+	pvcConditionInfeasible = v1.PersistentVolumeClaimCondition{
+		Type:    v1.PersistentVolumeClaimVolumeModifyingVolume,
+		Status:  v1.ConditionTrue,
+		Message: "ModifyVolume failed with errorrpc error: code = InvalidArgument desc = Parameters in VolumeAttributesClass is invalid. Waiting for retry.",
+	}
+
+	pvcConditionError = v1.PersistentVolumeClaimCondition{
+		Type:    v1.PersistentVolumeClaimVolumeModifyVolumeError,
+		Status:  v1.ConditionTrue,
+		Message: "ModifyVolume failed with error. Waiting for retry.",
+	}
+)
+
+func TestMarkControllerModifyVolumeStatus(t *testing.T) {
+	basePVC := testutil.MakeTestPVC([]v1.PersistentVolumeClaimCondition{})
+
+	tests := []struct {
+		name               string
+		pvc                *v1.PersistentVolumeClaim
+		expectedPVC        *v1.PersistentVolumeClaim
+		expectedConditions []v1.PersistentVolumeClaimCondition
+		expectedErr        error
+		testFunc           func(*v1.PersistentVolumeClaim, *modifyController) (*v1.PersistentVolumeClaim, error)
+	}{
+		{
+			name:               "mark modify volume as in progress",
+			pvc:                basePVC.Get(),
+			expectedPVC:        basePVC.WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInProgress).Get(),
+			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcConditionInProgress},
+			expectedErr:        nil,
+			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *modifyController) (*v1.PersistentVolumeClaim, error) {
+				return ctrl.markControllerModifyVolumeStatus(pvc, v1.PersistentVolumeClaimModifyVolumeInProgress, nil)
+			},
+		},
+		{
+			name:               "mark modify volume as infeasible",
+			pvc:                basePVC.Get(),
+			expectedPVC:        basePVC.WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInfeasible).Get(),
+			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcConditionInfeasible},
+			expectedErr:        infeasibleErr,
+			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *modifyController) (*v1.PersistentVolumeClaim, error) {
+				return ctrl.markControllerModifyVolumeStatus(pvc, v1.PersistentVolumeClaimModifyVolumeInfeasible, infeasibleErr)
+			},
+		},
+		{
+			name:               "mark modify volume as pending",
+			pvc:                basePVC.Get(),
+			expectedPVC:        basePVC.WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumePending).Get(),
+			expectedConditions: nil,
+			expectedErr:        nil,
+			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *modifyController) (*v1.PersistentVolumeClaim, error) {
+				return ctrl.markControllerModifyVolumeStatus(pvc, v1.PersistentVolumeClaimModifyVolumePending, nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)()
+			client := csi.NewMockClient("foo", true, true, true, true, true)
+			driverName, _ := client.GetDriverName(context.TODO())
+
+			pvc := test.pvc
+
+			var initialObjects []runtime.Object
+			initialObjects = append(initialObjects, test.pvc)
+
+			kubeClient, informerFactory := fakeK8s(initialObjects)
+
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			if err != nil {
+				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
+			}
+			controller := NewModifyController(driverName,
+				csiModifier, kubeClient,
+				time.Second, informerFactory,
+				workqueue.DefaultControllerRateLimiter())
+
+			ctrlInstance, _ := controller.(*modifyController)
+
+			pvc, err = tc.testFunc(pvc, ctrlInstance)
+			if err != nil && !reflect.DeepEqual(tc.expectedErr, err) {
+				t.Errorf("Expected error to be %v but got %v", tc.expectedErr, err)
+			}
+
+			realStatus := pvc.Status.ModifyVolumeStatus.Status
+			expectedStatus := tc.expectedPVC.Status.ModifyVolumeStatus.Status
+			if !reflect.DeepEqual(realStatus, expectedStatus) {
+				t.Errorf("expected modify volume status %+v got %+v", expectedStatus, realStatus)
+			}
+
+			realConditions := pvc.Status.Conditions
+			if !testutil.CompareConditions(realConditions, tc.expectedConditions) {
+				t.Errorf("expected conditions %+v got %+v", tc.expectedConditions, realConditions)
+			}
+		})
+	}
+}
+
+func TestUpdateConditionBasedOnError(t *testing.T) {
+	basePVC := testutil.MakeTestPVC([]v1.PersistentVolumeClaimCondition{})
+
+	tests := []struct {
+		name               string
+		pvc                *v1.PersistentVolumeClaim
+		expectedConditions []v1.PersistentVolumeClaimCondition
+		expectedErr        error
+	}{
+		{
+			name:               "update condition based on error",
+			pvc:                basePVC.Get(),
+			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcConditionError},
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)()
+			client := csi.NewMockClient("foo", true, true, true, true, true)
+			driverName, _ := client.GetDriverName(context.TODO())
+
+			pvc := test.pvc
+
+			var initialObjects []runtime.Object
+			initialObjects = append(initialObjects, test.pvc)
+
+			kubeClient, informerFactory := fakeK8s(initialObjects)
+
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			if err != nil {
+				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
+			}
+			controller := NewModifyController(driverName,
+				csiModifier, kubeClient,
+				time.Second, informerFactory,
+				workqueue.DefaultControllerRateLimiter())
+
+			ctrlInstance, _ := controller.(*modifyController)
+
+			pvc, err = ctrlInstance.updateConditionBasedOnError(tc.pvc, err)
+			if err != nil && !reflect.DeepEqual(tc.expectedErr, err) {
+				t.Errorf("Expected error to be %v but got %v", tc.expectedErr, err)
+			}
+
+			if !testutil.CompareConditions(pvc.Status.Conditions, tc.expectedConditions) {
+				t.Errorf("expected conditions %+v got %+v", tc.expectedConditions, pvc.Status.Conditions)
+			}
+		})
+	}
+}
+
+func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
+	basePVC := testutil.MakeTestPVC([]v1.PersistentVolumeClaimCondition{})
+	basePV := createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, testVac)
+	expectedPV := basePV.DeepCopy()
+	expectedPV.Spec.VolumeAttributesClassName = &targetVac
+	expectedPVC := basePVC.WithCurrentVolumeAttributesClassName(targetVac).Get()
+
+	tests := []struct {
+		name        string
+		pvc         *v1.PersistentVolumeClaim
+		pv          *v1.PersistentVolume
+		expectedPVC *v1.PersistentVolumeClaim
+		expectedPV  *v1.PersistentVolume
+		expectedErr error
+	}{
+		{
+			name:        "update modify volume status to completed",
+			pvc:         basePVC.Get(),
+			pv:          basePV,
+			expectedPVC: basePVC.WithCurrentVolumeAttributesClassName(targetVac).Get(),
+			expectedPV:  expectedPV,
+		},
+		{
+			name:        "update modify volume status to completed, and clear conditions",
+			pvc:         basePVC.WithConditions([]v1.PersistentVolumeClaimCondition{pvcConditionInProgress}).Get(),
+			pv:          basePV,
+			expectedPVC: expectedPVC,
+			expectedPV:  expectedPV,
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)()
+			client := csi.NewMockClient("foo", true, true, true, true, true)
+			driverName, _ := client.GetDriverName(context.TODO())
+
+			var initialObjects []runtime.Object
+			initialObjects = append(initialObjects, test.pvc)
+			initialObjects = append(initialObjects, test.pv)
+
+			kubeClient, informerFactory := fakeK8s(initialObjects)
+
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			if err != nil {
+				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
+			}
+			controller := NewModifyController(driverName,
+				csiModifier, kubeClient,
+				time.Second, informerFactory,
+				workqueue.DefaultControllerRateLimiter())
+
+			ctrlInstance, _ := controller.(*modifyController)
+
+			actualPVC, pv, err := ctrlInstance.markControllerModifyVolumeCompleted(tc.pvc, tc.pv)
+			if err != nil && !reflect.DeepEqual(tc.expectedErr, err) {
+				t.Errorf("Expected error to be %v but got %v", tc.expectedErr, err)
+			}
+
+			if len(actualPVC.Status.Conditions) == 0 {
+				actualPVC.Status.Conditions = []v1.PersistentVolumeClaimCondition{}
+			}
+
+			if diff := cmp.Diff(tc.expectedPVC, actualPVC); diff != "" {
+				t.Errorf("expected pvc %+v got %+v, diff is: %v", tc.expectedPVC, actualPVC, diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedPV, pv); diff != "" {
+				t.Errorf("expected pvc %+v got %+v, diff is: %v", tc.expectedPV, pv, diff)
+			}
+		})
+	}
+}
+
+func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
+	basePVC := testutil.MakeTestPVC([]v1.PersistentVolumeClaimCondition{})
+	basePVC.WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInProgress)
+	secondPVC := testutil.GetTestPVC("test-vol0", "2G", "1G", "", "")
+	secondPVC.Status.Phase = v1.ClaimBound
+	secondPVC.Status.ModifyVolumeStatus = &v1.ModifyVolumeStatus{}
+	secondPVC.Status.ModifyVolumeStatus.Status = v1.PersistentVolumeClaimModifyVolumeInfeasible
+
+	tests := []struct {
+		name string
+		pvc  *v1.PersistentVolumeClaim
+	}{
+		{
+			name: "should delete the target pvc but keep the others in the cache",
+			pvc:  basePVC.Get(),
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)()
+			client := csi.NewMockClient("foo", true, true, true, true, true)
+			driverName, _ := client.GetDriverName(context.TODO())
+
+			var initialObjects []runtime.Object
+			initialObjects = append(initialObjects, test.pvc)
+			initialObjects = append(initialObjects, secondPVC)
+
+			kubeClient, informerFactory := fakeK8s(initialObjects)
+			pvInformer := informerFactory.Core().V1().PersistentVolumes()
+			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
+			podInformer := informerFactory.Core().V1().Pods()
+			vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			if err != nil {
+				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
+			}
+			controller := NewModifyController(driverName,
+				csiModifier, kubeClient,
+				time.Second, informerFactory,
+				workqueue.DefaultControllerRateLimiter())
+
+			ctrlInstance, _ := controller.(*modifyController)
+
+			stopCh := make(chan struct{})
+			informerFactory.Start(stopCh)
+
+			ctx := context.TODO()
+			defer ctx.Done()
+			go controller.Run(1, ctx)
+
+			for _, obj := range initialObjects {
+				switch obj.(type) {
+				case *v1.PersistentVolume:
+					pvInformer.Informer().GetStore().Add(obj)
+				case *v1.PersistentVolumeClaim:
+					pvcInformer.Informer().GetStore().Add(obj)
+				case *v1.Pod:
+					podInformer.Informer().GetStore().Add(obj)
+				case *storagev1alpha1.VolumeAttributesClass:
+					vacInformer.Informer().GetStore().Add(obj)
+				default:
+					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)
+				}
+			}
+
+			time.Sleep(time.Second * 2)
+
+			err = ctrlInstance.removePVCFromModifyVolumeUncertainCache(tc.pvc)
+			if err != nil {
+				t.Errorf("err deleting pvc: %v", tc.pvc)
+			}
+
+			deletedPVCKey, err := cache.MetaNamespaceKeyFunc(tc.pvc)
+			if err != nil {
+				t.Errorf("failed to extract pvc key from pvc %v", tc.pvc)
+			}
+			_, ok := ctrlInstance.uncertainPVCs[deletedPVCKey]
+			if ok {
+				t.Errorf("pvc %v should be deleted but it is still in the uncertainPVCs cache", tc.pvc)
+			}
+			if err != nil {
+				t.Errorf("err get pvc %v from uncertainPVCs: %v", tc.pvc, err)
+			}
+
+			notDeletedPVCKey, err := cache.MetaNamespaceKeyFunc(secondPVC)
+			if err != nil {
+				t.Errorf("failed to extract pvc key from secondPVC %v", secondPVC)
+			}
+			_, ok = ctrlInstance.uncertainPVCs[notDeletedPVCKey]
+			if !ok {
+				t.Errorf("pvc %v should not be deleted, uncertainPVCs list %v", secondPVC, ctrlInstance.uncertainPVCs)
+			}
+			if err != nil {
+				t.Errorf("err get pvc %v from uncertainPVCs: %v", secondPVC, err)
+			}
+		})
+	}
+}
+
+func createTestPV(capacityGB int, pvcName, pvcNamespace string, pvcUID types.UID, volumeMode *v1.PersistentVolumeMode, vacName string) *v1.PersistentVolume {
+	capacity := testutil.QuantityGB(capacityGB)
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testPV",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Capacity: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceStorage: capacity,
+			},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       "foo",
+					VolumeHandle: "foo",
+				},
+			},
+			VolumeMode:                volumeMode,
+			VolumeAttributesClassName: &vacName,
+		},
+	}
+	if len(pvcName) > 0 {
+		pv.Spec.ClaimRef = &v1.ObjectReference{
+			Namespace: pvcNamespace,
+			Name:      pvcName,
+			UID:       pvcUID,
+		}
+		pv.Status.Phase = v1.VolumeBound
+	}
+	return pv
+}

--- a/pkg/modifycontroller/modify_volume.go
+++ b/pkg/modifycontroller/modify_volume.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifycontroller
+
+import (
+	"fmt"
+
+	"github.com/kubernetes-csi/external-resizer/pkg/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// The return value bool is only used as a sentinel value when function returns without actually performing modification
+func (ctrl *modifyController) modify(pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error, bool) {
+	pvcSpecVacName := pvc.Spec.VolumeAttributesClassName
+	curVacName := pvc.Status.CurrentVolumeAttributesClassName
+
+	if pvcSpecVacName != nil && curVacName == nil {
+		// First time adding VAC to a PVC
+		return ctrl.validateVACAndModifyVolumeWithTarget(pvc, pv)
+	} else if pvcSpecVacName != nil && curVacName != nil && *pvcSpecVacName != *curVacName {
+		targetVacName := *pvcSpecVacName
+		if pvc.Status.ModifyVolumeStatus != nil {
+			targetVacName = pvc.Status.ModifyVolumeStatus.TargetVolumeAttributesClassName
+		}
+		if *curVacName == targetVacName {
+			return ctrl.validateVACAndModifyVolumeWithTarget(pvc, pv)
+		} else {
+			// Check if the PVC is in uncertain State
+			pvcKey, err := cache.MetaNamespaceKeyFunc(pvc)
+			if err != nil {
+				return pvc, pv, err, false
+			}
+			_, ok := ctrl.uncertainPVCs[pvcKey]
+			if !ok {
+				// PVC is not in uncertain state
+				klog.V(3).InfoS("previous operation on the PVC failed with a final error, retrying")
+				return ctrl.validateVACAndModifyVolumeWithTarget(pvc, pv)
+			} else {
+				vac, err := ctrl.vacLister.Get(*pvcSpecVacName)
+				if err != nil {
+					return pvc, pv, err, false
+				}
+				return ctrl.controllerModifyVolumeWithTarget(pvc, pv, vac, pvcSpecVacName)
+			}
+		}
+
+	}
+	// No modification required
+	return pvc, pv, nil, false
+}
+
+// func validateVACAndModifyVolumeWithTarget validate the VAC. The function sets pvc.Status.ModifyVolumeStatus
+// to Pending if VAC does not exist and proceeds to trigger ModifyVolume if VAC exists
+func (ctrl *modifyController) validateVACAndModifyVolumeWithTarget(
+	pvc *v1.PersistentVolumeClaim,
+	pv *v1.PersistentVolume) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error, bool) {
+	// The controller only triggers ModifyVolume if pvcSpecVacName is not nil nor empty
+	pvcSpecVacName := pvc.Spec.VolumeAttributesClassName
+	// Check if pvcSpecVac is valid and exist
+	vac, err := ctrl.vacLister.Get(*pvcSpecVacName)
+	if err == nil {
+		// Mark pvc.Status.ModifyVolumeStatus as in progress
+		pvc, err = ctrl.markControllerModifyVolumeStatus(pvc, v1.PersistentVolumeClaimModifyVolumeInProgress, nil)
+		if err != nil {
+			return pvc, pv, err, false
+		}
+		// Record an event to indicate that external resizer is modifying this volume.
+		ctrl.eventRecorder.Event(pvc, v1.EventTypeNormal, util.VolumeModify,
+			fmt.Sprintf("external resizer is modifying volume %s with vac %s", pvc.Name, *pvcSpecVacName))
+		return ctrl.controllerModifyVolumeWithTarget(pvc, pv, vac, pvcSpecVacName)
+	} else {
+		klog.Errorf("Get VAC with vac name %s in VACInformer cache failed: %v", *pvcSpecVacName, err)
+		// Mark pvc.Status.ModifyVolumeStatus as pending
+		pvc, err = ctrl.markControllerModifyVolumeStatus(pvc, v1.PersistentVolumeClaimModifyVolumePending, nil)
+		return pvc, pv, err, false
+	}
+}
+
+// func controllerModifyVolumeWithTarget trigger the CSI ControllerModifyVolume API call
+// and handle both success and error scenarios
+func (ctrl *modifyController) controllerModifyVolumeWithTarget(
+	pvc *v1.PersistentVolumeClaim,
+	pv *v1.PersistentVolume,
+	vacObj *storagev1alpha1.VolumeAttributesClass,
+	pvcSpecVacName *string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error, bool) {
+	var err error
+	pvc, pv, err = ctrl.callModifyVolumeOnPlugin(pvc, pv, vacObj)
+	if err == nil {
+		klog.V(4).Infof("Update volumeAttributesClass of PV %q to %s succeeded", pv.Name, *pvcSpecVacName)
+		// Record an event to indicate that modify operation is successful.
+		ctrl.eventRecorder.Eventf(pvc, v1.EventTypeNormal, util.VolumeModifySuccess, fmt.Sprintf("external resizer modified volume %s with vac %s successfully ", pvc.Name, vacObj.Name))
+		return pvc, pv, nil, true
+	} else {
+		status, ok := status.FromError(err)
+		if ok {
+			ctrl.updateConditionBasedOnError(pvc, err)
+			if !util.IsFinalError(err) {
+				// update conditions and cache pvc as uncertain
+				pvcKey, err := cache.MetaNamespaceKeyFunc(pvc)
+				if err != nil {
+					return pvc, pv, err, false
+				}
+				ctrl.uncertainPVCs[pvcKey] = *pvc
+
+			} else {
+				// Only InvalidArgument can be set to Infeasible state
+				// Final errors other than InvalidArgument will still be in InProgress state
+				if status.Code() == codes.InvalidArgument {
+					// Mark pvc.Status.ModifyVolumeStatus as infeasible
+					pvc, markModifyVolumeInfeasibleError := ctrl.markControllerModifyVolumeStatus(pvc, v1.PersistentVolumeClaimModifyVolumeInfeasible, err)
+					if markModifyVolumeInfeasibleError != nil {
+						return pvc, pv, markModifyVolumeInfeasibleError, false
+					}
+				}
+				ctrl.removePVCFromModifyVolumeUncertainCache(pvc)
+			}
+		} else {
+			return pvc, pv, fmt.Errorf("cannot get error status from modify volume err: %v ", err), false
+		}
+		// Record an event to indicate that modify operation is failed.
+		ctrl.eventRecorder.Eventf(pvc, v1.EventTypeWarning, util.VolumeModifyFailed, err.Error())
+		return pvc, pv, err, false
+	}
+}
+
+func (ctrl *modifyController) callModifyVolumeOnPlugin(
+	pvc *v1.PersistentVolumeClaim,
+	pv *v1.PersistentVolume,
+	vac *storagev1alpha1.VolumeAttributesClass) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
+	err := ctrl.modifier.Modify(pv, vac.Parameters)
+
+	if err != nil {
+		return pvc, pv, err
+	}
+
+	pvc, pv, err = ctrl.markControllerModifyVolumeCompleted(pvc, pv)
+	if err != nil {
+		return pvc, pv, fmt.Errorf("modify volume failed to mark pvc %s modify volume completed: %v ", pvc.Name, err)
+	}
+	return pvc, pv, nil
+}

--- a/pkg/modifycontroller/modify_volume_test.go
+++ b/pkg/modifycontroller/modify_volume_test.go
@@ -1,0 +1,202 @@
+package modifycontroller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubernetes-csi/external-resizer/pkg/csi"
+	"github.com/kubernetes-csi/external-resizer/pkg/features"
+	"github.com/kubernetes-csi/external-resizer/pkg/modifier"
+	v1 "k8s.io/api/core/v1"
+	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+var (
+	testVacObject = &storagev1alpha1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: testVac},
+		DriverName: "test-driver",
+		Parameters: map[string]string{"iops": "3000"},
+	}
+
+	targetVacObject = &storagev1alpha1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: targetVac},
+		DriverName: "test-driver",
+		Parameters: map[string]string{"iops": "4567"},
+	}
+)
+
+func TestModify(t *testing.T) {
+	basePVC := createTestPVC(pvcName, testVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/)
+	basePV := createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, testVac)
+
+	var tests = []struct {
+		name                                     string
+		pvc                                      *v1.PersistentVolumeClaim
+		pv                                       *v1.PersistentVolume
+		vacExists                                bool
+		expectModifyCall                         bool
+		expectedModifyVolumeStatus               *v1.ModifyVolumeStatus
+		expectedCurrentVolumeAttributesClassName *string
+		expectedPVVolumeAttributesClassName      *string
+	}{
+		{
+			name:                                     "nothing to modify",
+			pvc:                                      basePVC,
+			pv:                                       basePV,
+			expectModifyCall:                         false,
+			expectedModifyVolumeStatus:               basePVC.Status.ModifyVolumeStatus,
+			expectedCurrentVolumeAttributesClassName: &testVac,
+			expectedPVVolumeAttributesClassName:      &testVac,
+		},
+		{
+			name:             "vac does not exist, no modification and set ModifyVolumeStatus to pending",
+			pvc:              createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
+			pv:               basePV,
+			expectModifyCall: false,
+			expectedModifyVolumeStatus: &v1.ModifyVolumeStatus{
+				TargetVolumeAttributesClassName: testVac,
+				Status:                          v1.PersistentVolumeClaimModifyVolumePending,
+			},
+			expectedCurrentVolumeAttributesClassName: &testVac,
+			expectedPVVolumeAttributesClassName:      &testVac,
+		},
+		{
+			name:             "modify volume success",
+			pvc:              createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
+			pv:               basePV,
+			vacExists:        true,
+			expectModifyCall: true,
+			expectedModifyVolumeStatus: &v1.ModifyVolumeStatus{
+				TargetVolumeAttributesClassName: targetVac,
+				Status:                          "",
+			},
+			expectedCurrentVolumeAttributesClassName: &targetVac,
+			expectedPVVolumeAttributesClassName:      &targetVac,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			// Setup
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)()
+			client := csi.NewMockClient("foo", true, true, true, true, true)
+			driverName, _ := client.GetDriverName(context.TODO())
+
+			var initialObjects []runtime.Object
+			initialObjects = append(initialObjects, test.pvc)
+			initialObjects = append(initialObjects, test.pv)
+			// existing vac set in the pvc and pv
+			initialObjects = append(initialObjects, testVacObject)
+			if test.vacExists {
+				initialObjects = append(initialObjects, targetVacObject)
+			}
+
+			kubeClient, informerFactory := fakeK8s(initialObjects)
+			pvInformer := informerFactory.Core().V1().PersistentVolumes()
+			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
+			vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			if err != nil {
+				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
+			}
+			controller := NewModifyController(driverName,
+				csiModifier, kubeClient,
+				time.Second, informerFactory,
+				workqueue.DefaultControllerRateLimiter())
+
+			ctrlInstance, _ := controller.(*modifyController)
+
+			stopCh := make(chan struct{})
+			informerFactory.Start(stopCh)
+
+			for _, obj := range initialObjects {
+				switch obj.(type) {
+				case *v1.PersistentVolume:
+					pvInformer.Informer().GetStore().Add(obj)
+				case *v1.PersistentVolumeClaim:
+					pvcInformer.Informer().GetStore().Add(obj)
+				case *storagev1alpha1.VolumeAttributesClass:
+					vacInformer.Informer().GetStore().Add(obj)
+				default:
+					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)
+				}
+			}
+			// Action
+			pvc, pv, err, modifyCalled := ctrlInstance.modify(test.pvc, test.pv)
+			// Verify
+
+			if err != nil {
+				t.Errorf("modify failed with %v", err)
+			}
+			if test.expectModifyCall != modifyCalled {
+				t.Errorf("modify volume failed: expected modify called %t, got %t", test.expectModifyCall, modifyCalled)
+			}
+
+			actualModifyVolumeStatus := pvc.Status.ModifyVolumeStatus
+
+			if diff := cmp.Diff(test.expectedModifyVolumeStatus, actualModifyVolumeStatus); diff != "" {
+				t.Errorf("expected modify volume status to be %v, got %v", test.expectedModifyVolumeStatus, actualModifyVolumeStatus)
+			}
+
+			actualCurrentVolumeAttributesClassName := pvc.Status.CurrentVolumeAttributesClassName
+
+			if diff := cmp.Diff(*test.expectedCurrentVolumeAttributesClassName, *actualCurrentVolumeAttributesClassName); diff != "" {
+				t.Errorf("expected CurrentVolumeAttributesClassName to be %v, got %v", *test.expectedCurrentVolumeAttributesClassName, *actualCurrentVolumeAttributesClassName)
+			}
+
+			actualPVVolumeAttributesClassName := pv.Spec.VolumeAttributesClassName
+			if diff := cmp.Diff(*test.expectedPVVolumeAttributesClassName, *actualPVVolumeAttributesClassName); diff != "" {
+				t.Errorf("expected VolumeAttributesClassName of pv to be %v, got %v", *test.expectedPVVolumeAttributesClassName, *actualPVVolumeAttributesClassName)
+			}
+		})
+	}
+}
+
+func createTestPVC(pvcName string, vacName string, curVacName string, targetVacName string) *v1.PersistentVolumeClaim {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: "modify"},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadOnlyMany,
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("2Gi"),
+				},
+			},
+			VolumeAttributesClassName: &vacName,
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("2Gi"),
+			},
+			CurrentVolumeAttributesClassName: &curVacName,
+			ModifyVolumeStatus: &v1.ModifyVolumeStatus{
+				TargetVolumeAttributesClassName: targetVacName,
+				Status:                          "",
+			},
+		},
+	}
+	return pvc
+}
+
+func fakeK8s(objs []runtime.Object) (kubernetes.Interface, informers.SharedInformerFactory) {
+	client := fake.NewSimpleClientset(objs...)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	return client, informerFactory
+}

--- a/pkg/resizer/csi_resizer_test.go
+++ b/pkg/resizer/csi_resizer_test.go
@@ -44,6 +44,15 @@ func TestNewResizer(t *testing.T) {
 
 			Error: controllerServiceNotSupportErr,
 		},
+		// Controller modify not supported.
+		{
+			SupportsNodeResize:                      true,
+			SupportsControllerResize:                true,
+			SupportsPluginControllerService:         true,
+			SupportsControllerSingleNodeMultiWriter: true,
+
+			Trivial: false,
+		},
 		// Only node resize supported.
 		{
 			SupportsNodeResize:                      true,
@@ -63,7 +72,7 @@ func TestNewResizer(t *testing.T) {
 			Error: resizeNotSupportErr,
 		},
 	} {
-		client := csi.NewMockClient("mock", c.SupportsNodeResize, c.SupportsControllerResize, c.SupportsPluginControllerService, c.SupportsControllerSingleNodeMultiWriter)
+		client := csi.NewMockClient("mock", c.SupportsNodeResize, c.SupportsControllerResize, false, c.SupportsPluginControllerService, c.SupportsControllerSingleNodeMultiWriter)
 		driverName := "mock-driver"
 		k8sClient := fake.NewSimpleClientset()
 		resizer, err := NewResizerFromClient(client, 0, k8sClient, driverName)
@@ -97,7 +106,7 @@ func TestResizeWithSecret(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		client := csi.NewMockClient("mock", true, true, true, true)
+		client := csi.NewMockClient("mock", true, true, false, true, true)
 		secret := makeSecret("some-secret", "secret-namespace")
 		k8sClient := fake.NewSimpleClientset(secret)
 		pv := makeTestPV("test-csi", 2, "ebs-csi", "vol-abcde", tc.hasExpansionSecret)
@@ -155,7 +164,7 @@ func TestResizeMigratedPV(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			driverName := tc.driverName
-			client := csi.NewMockClient(driverName, true, true, true, true)
+			client := csi.NewMockClient(driverName, true, true, false, true, true)
 			client.SetCheckMigratedLabel()
 			k8sClient := fake.NewSimpleClientset()
 			resizer, err := NewResizerFromClient(client, 0, k8sClient, driverName)
@@ -424,7 +433,7 @@ func TestCanSupport(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			driverName := tc.driverName
-			client := csi.NewMockClient(driverName, true, true, true, true)
+			client := csi.NewMockClient(driverName, true, true, false, true, true)
 			k8sClient := fake.NewSimpleClientset()
 			resizer, err := NewResizerFromClient(client, 0, k8sClient, driverName)
 			if err != nil {

--- a/pkg/resizer/trivial_resizer.go
+++ b/pkg/resizer/trivial_resizer.go
@@ -18,7 +18,7 @@ package resizer
 
 import (
 	"github.com/kubernetes-csi/external-resizer/pkg/util"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/klog/v2"

--- a/pkg/testutil/test_util.go
+++ b/pkg/testutil/test_util.go
@@ -1,0 +1,171 @@
+package testutil
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	pvcName   = "foo"
+	defaultNS = "default"
+)
+
+var (
+	testVac   = "test-vac"
+	targetVac = "target-vac"
+)
+
+func GetTestPVC(volumeName string, specSize, statusSize, allocatedSize string, resizeStatus v1.ClaimResourceStatus) *v1.PersistentVolumeClaim {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "claim01",
+			Namespace: defaultNS,
+			UID:       "test-uid",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources:   v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse(specSize)}},
+			VolumeName:  volumeName,
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+		},
+	}
+	if len(statusSize) > 0 {
+		pvc.Status.Capacity = v1.ResourceList{v1.ResourceStorage: resource.MustParse(statusSize)}
+	}
+	if len(allocatedSize) > 0 {
+		pvc.Status.AllocatedResources = v1.ResourceList{v1.ResourceStorage: resource.MustParse(allocatedSize)}
+	}
+	if len(resizeStatus) > 0 {
+		pvc.Status.AllocatedResourceStatuses = map[v1.ResourceName]v1.ClaimResourceStatus{
+			v1.ResourceStorage: resizeStatus,
+		}
+	}
+	return pvc
+}
+
+type pvcModifier struct {
+	pvc *v1.PersistentVolumeClaim
+}
+
+func MakePVC(conditions []v1.PersistentVolumeClaimCondition) pvcModifier {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "resize"},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadOnlyMany,
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("2Gi"),
+				},
+			},
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase:      v1.ClaimBound,
+			Conditions: conditions,
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("2Gi"),
+			},
+		},
+	}
+	return pvcModifier{pvc}
+}
+
+func MakeTestPVC(conditions []v1.PersistentVolumeClaimCondition) pvcModifier {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: "modify"},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadOnlyMany,
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("2Gi"),
+				},
+			},
+			VolumeAttributesClassName: &targetVac,
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase:      v1.ClaimBound,
+			Conditions: conditions,
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("2Gi"),
+			},
+			CurrentVolumeAttributesClassName: &testVac,
+			ModifyVolumeStatus: &v1.ModifyVolumeStatus{
+				TargetVolumeAttributesClassName: targetVac,
+			},
+		},
+	}
+	return pvcModifier{pvc}
+}
+
+func (m pvcModifier) WithModifyVolumeStatus(status v1.PersistentVolumeClaimModifyVolumeStatus) pvcModifier {
+	if m.pvc.Status.ModifyVolumeStatus == nil {
+		m.pvc.Status.ModifyVolumeStatus = &v1.ModifyVolumeStatus{}
+	}
+	m.pvc.Status.ModifyVolumeStatus.Status = status
+	return m
+}
+
+func (m pvcModifier) WithCurrentVolumeAttributesClassName(currentVacName string) pvcModifier {
+	if m.pvc.Status.ModifyVolumeStatus == nil {
+		m.pvc.Status.ModifyVolumeStatus = &v1.ModifyVolumeStatus{}
+	}
+	m.pvc.Status.CurrentVolumeAttributesClassName = &currentVacName
+	return m
+}
+
+func (m pvcModifier) WithConditions(conditions []v1.PersistentVolumeClaimCondition) pvcModifier {
+	m.pvc.Status.Conditions = conditions
+	return m
+}
+
+func CompareConditions(realConditions, expectedConditions []v1.PersistentVolumeClaimCondition) bool {
+	if realConditions == nil && expectedConditions == nil {
+		return true
+	}
+	if (realConditions == nil || expectedConditions == nil) || len(realConditions) != len(expectedConditions) {
+		return false
+	}
+
+	for i, condition := range realConditions {
+		if condition.Type != expectedConditions[i].Type || condition.Message != expectedConditions[i].Message || condition.Status != expectedConditions[i].Status {
+			return false
+		}
+	}
+	return true
+}
+
+func (m pvcModifier) Get() *v1.PersistentVolumeClaim {
+	return m.pvc.DeepCopy()
+}
+
+func (m pvcModifier) WithStorageResourceStatus(status v1.ClaimResourceStatus) pvcModifier {
+	return m.WithResourceStatus(v1.ResourceStorage, status)
+}
+
+func (m pvcModifier) WithResourceStatus(resource v1.ResourceName, status v1.ClaimResourceStatus) pvcModifier {
+	if m.pvc.Status.AllocatedResourceStatuses != nil && status == "" {
+		delete(m.pvc.Status.AllocatedResourceStatuses, resource)
+		return m
+	}
+	if m.pvc.Status.AllocatedResourceStatuses != nil {
+		m.pvc.Status.AllocatedResourceStatuses[resource] = status
+	} else {
+		m.pvc.Status.AllocatedResourceStatuses = map[v1.ResourceName]v1.ClaimResourceStatus{
+			resource: status,
+		}
+	}
+	return m
+}
+
+func QuantityGB(i int) resource.Quantity {
+	q := resource.NewQuantity(int64(i*1024*1024*1024), resource.BinarySI)
+	return *q
+}

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -21,6 +21,9 @@ const (
 	VolumeResizing           = "Resizing"
 	VolumeResizeFailed       = "VolumeResizeFailed"
 	VolumeResizeSuccess      = "VolumeResizeSuccessful"
+	VolumeModify             = "VolumeModify"
+	VolumeModifyFailed       = "VolumeModifyFailed"
+	VolumeModifySuccess      = "VolumeModifySuccessful"
 	FileSystemResizeRequired = "FileSystemResizeRequired"
 )
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,20 +17,33 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 )
 
 var (
 	knownResizeConditions = map[v1.PersistentVolumeClaimConditionType]bool{
 		v1.PersistentVolumeClaimResizing:                true,
 		v1.PersistentVolumeClaimFileSystemResizePending: true,
+	}
+
+	knownModifyVolumeConditions = map[v1.PersistentVolumeClaimConditionType]bool{
+		v1.PersistentVolumeClaimVolumeModifyingVolume:   true,
+		v1.PersistentVolumeClaimVolumeModifyVolumeError: true,
 	}
 
 	// AnnPreResizeCapacity annotation is added to a PV when expanding volume.
@@ -65,6 +78,37 @@ func MergeResizeConditionsOfPVC(oldConditions, newConditions []v1.PersistentVolu
 	}
 
 	// Append remains resize conditions.
+	for _, condition := range newConditionSet {
+		resultConditions = append(resultConditions, condition)
+	}
+
+	return resultConditions
+}
+
+// MergeModifyVolumeConditionsOfPVC updates pvc with requested modify volume conditions
+// leaving other conditions untouched.
+func MergeModifyVolumeConditionsOfPVC(oldConditions, newConditions []v1.PersistentVolumeClaimCondition) []v1.PersistentVolumeClaimCondition {
+	newConditionSet := make(map[v1.PersistentVolumeClaimConditionType]v1.PersistentVolumeClaimCondition, len(newConditions))
+	for _, condition := range newConditions {
+		newConditionSet[condition.Type] = condition
+	}
+
+	resultConditions := []v1.PersistentVolumeClaimCondition{}
+	for _, condition := range oldConditions {
+		// If Condition is not modifyVolume type, we keep it.
+		if _, ok := knownModifyVolumeConditions[condition.Type]; !ok {
+			resultConditions = append(resultConditions, condition)
+			continue
+		}
+		if newCondition, ok := newConditionSet[condition.Type]; ok {
+			// Use the new condition to replace old condition with same type.
+			resultConditions = append(resultConditions, newCondition)
+			delete(newConditionSet, condition.Type)
+		}
+		// Drop other modify volume conditions that are not in the newConditionSet
+	}
+
+	// Append remains modify volume conditions.
 	for _, condition := range newConditionSet {
 		resultConditions = append(resultConditions, condition)
 	}
@@ -142,4 +186,69 @@ func SanitizeName(name string) string {
 		name = name + "X"
 	}
 	return name
+}
+
+func GetObjectKey(obj interface{}) (string, error) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
+	objKey, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get key from object")
+		return "", err
+	}
+	return objKey, nil
+}
+
+// Patches a given PVC with changes from newPVC. If addResourceVersionCheck is true
+// then a version check is added to the patch to ensure that we are not patching
+// old(and possibly outdated) PVC objects.
+func PatchClaim(kubeClient kubernetes.Interface, oldPVC, newPVC *v1.PersistentVolumeClaim, addResourceVersionCheck bool) (*v1.PersistentVolumeClaim, error) {
+	patchBytes, err := GetPVCPatchData(oldPVC, newPVC, addResourceVersionCheck)
+	if err != nil {
+		return oldPVC, fmt.Errorf("can't patch status of PVC %s as generate path data failed: %v", klog.KObj(oldPVC), err)
+	}
+	updatedClaim, updateErr := kubeClient.CoreV1().PersistentVolumeClaims(oldPVC.Namespace).
+		Patch(context.TODO(), oldPVC.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	if updateErr != nil {
+		return oldPVC, fmt.Errorf("can't patch status of  PVC %s with %v", klog.KObj(oldPVC), updateErr)
+	}
+
+	return updatedClaim, nil
+}
+
+func PatchPersistentVolume(kubeClient kubernetes.Interface, oldPV, newPV *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	patchBytes, err := GetPatchData(oldPV, newPV)
+	if err != nil {
+		return nil, fmt.Errorf("can't update capacity of PV %s as generate path data failed: %v", newPV.Name, err)
+	}
+	updatedPV, updateErr := kubeClient.CoreV1().PersistentVolumes().Patch(context.TODO(), newPV.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	if updateErr != nil {
+		return nil, fmt.Errorf("update capacity of PV %s failed: %v", newPV.Name, updateErr)
+	}
+	return updatedPV, nil
+}
+
+func IsFinalError(err error) bool {
+	// Sources:
+	// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+	// https://github.com/container-storage-interface/spec/blob/master/spec.md
+	st, ok := status.FromError(err)
+	if !ok {
+		// This is not gRPC error. The operation must have failed before gRPC
+		// method was called, otherwise we would get gRPC error.
+		// We don't know if any previous volume operation is in progress, be on the safe side.
+		return false
+	}
+	switch st.Code() {
+	case codes.Canceled, // gRPC: Client Application cancelled the request
+		codes.DeadlineExceeded,  // gRPC: Timeout
+		codes.Unavailable,       // gRPC: Server shutting down, TCP connection broken - previous volume operation may be still in progress.
+		codes.ResourceExhausted, // gRPC: Server temporarily out of resources - previous volume operation may be still in progress.
+		codes.Aborted:           // CSI: Operation pending for volume
+		return false
+	}
+	// All other errors mean that operation either did not
+	// even start or failed. It is for sure not in progress.
+	return true
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -2,10 +2,33 @@ package util
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	pvcOldCondition = v1.PersistentVolumeClaimCondition{
+		Type:               v1.PersistentVolumeClaimFileSystemResizePending,
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Message:            "Waiting for user to (re-)start a pod to finish file system resize of volume on node.",
+	}
+	pvcConditionInProgress = v1.PersistentVolumeClaimCondition{
+		Type:               v1.PersistentVolumeClaimVolumeModifyingVolume,
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Message:            "ModifyVolume operation in progress.",
+	}
+
+	pvcConditionInfeasible = v1.PersistentVolumeClaimCondition{
+		Type:               v1.PersistentVolumeClaimVolumeModifyingVolume,
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Message:            "ModifyVolume operation in progress.",
+	}
 )
 
 func TestGetPVCPatchData(t *testing.T) {
@@ -38,5 +61,49 @@ func TestGetPVCPatchData(t *testing.T) {
 			t.Errorf("Case %d: ResourceVersion should be %s, got %s",
 				i, c.OldPVC.ResourceVersion, resourceVersion)
 		}
+	}
+}
+
+func TestMergeModifyVolumeConditionsOfPVC(t *testing.T) {
+	tests := []struct {
+		name               string
+		oldConditions      []v1.PersistentVolumeClaimCondition
+		newConditions      []v1.PersistentVolumeClaimCondition
+		expectedConditions []v1.PersistentVolumeClaimCondition
+	}{
+		{
+			name:               "merge new modify volume condition with old resize condition",
+			oldConditions:      []v1.PersistentVolumeClaimCondition{pvcOldCondition},
+			newConditions:      []v1.PersistentVolumeClaimCondition{pvcConditionInProgress},
+			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcOldCondition, pvcConditionInProgress},
+		},
+		{
+			name:               "merge new modify volume condition with old modify volume condition",
+			oldConditions:      []v1.PersistentVolumeClaimCondition{pvcConditionInProgress},
+			newConditions:      []v1.PersistentVolumeClaimCondition{pvcConditionInfeasible},
+			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcConditionInfeasible},
+		},
+		{
+			name:               "merge empty condition with old modify volume condition",
+			oldConditions:      []v1.PersistentVolumeClaimCondition{pvcConditionInProgress},
+			newConditions:      []v1.PersistentVolumeClaimCondition{},
+			expectedConditions: []v1.PersistentVolumeClaimCondition{},
+		},
+		{
+			name:               "merge new condition with old empty volume condition",
+			oldConditions:      []v1.PersistentVolumeClaimCondition{},
+			newConditions:      []v1.PersistentVolumeClaimCondition{pvcConditionInProgress},
+			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcConditionInProgress},
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			resultConditions := MergeModifyVolumeConditionsOfPVC(tc.oldConditions, tc.newConditions)
+			if !reflect.DeepEqual(resultConditions, tc.expectedConditions) {
+				t.Errorf("expected conditions %+v got %+v", tc.expectedConditions, resultConditions)
+			}
+		})
 	}
 }


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Implement logic of [this diagram](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/3751-volume-attributes-class/VolumeAttributesClass-ModifyVolume-Flow-v3.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-csi/external-resizer/issues/314

**Special notes for your reviewer**:

**Testing Steps**

***Positive Test Cases***
1. Using kubetest at with k8s 1.29 change including VAC
```
KUBE_FEATURE_GATES="VolumeAttributesClass=true" kubetest --up --runtime-config=api/all=true
```
2. Build the container image of [external-resizer with logs](https://github.com/kubernetes-csi/external-resizer/compare/master...sunnylovestiramisu:external-resizer:modifyVolumeTesting)
3. Set up csi-driver-host-path with the resizer image built in step 2 as in [this branch](https://github.com/sunnylovestiramisu/csi-driver-host-path/tree/testModifyVolume)
4. Follow [deploy-1.17-and-later.md runbook](https://github.com/sunnylovestiramisu/csi-driver-host-path/blob/master/docs/deploy-1.17-and-later.md) to deploy hostpath driver in the cluster
5. Create csi-pvc, csi-storageclass, csi-volumeattributesclass, and csi-app 
```
// csi-volumeattributesclass.yaml
apiVersion: storage.k8s.io/v1alpha1
kind: VolumeAttributesClass
metadata:
  name: silver
driverName: hostpath.csi.k8s.io
parameters:
  provisioned-iops: "3000"
```
6. Modify the pvc with ``kubectl edit pvc csi-pvc`` and add ``volumeAttributesClassName: silver`` to the pvc
7. Verify modify volume is successful

```
csi-driver-host-path git:(testModifyVolume) ✗ k describe pvc
Name:          csi-pvc
Namespace:     default
StorageClass:  csi-hostpath-sc
Status:        Bound
Volume:        pvc-561aca0d-a67b-4cb1-81c3-791b5c654423
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: hostpath.csi.k8s.io
               volume.kubernetes.io/storage-provisioner: hostpath.csi.k8s.io
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       my-csi-app
Events:
  Type    Reason                  Age                From                                                                           Message
  ----    ------                  ----               ----                                                                           -------
  Normal  ExternalProvisioning    49s (x2 over 49s)  persistentvolume-controller                                                    Waiting for a volume to be created either by the external provisioner 'hostpath.csi.k8s.io' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  Provisioning            49s                hostpath.csi.k8s.io_csi-hostpathplugin-0_a9a3cc54-1f3f-4f2c-9304-0cfe731945b6  External provisioner is provisioning volume for claim "default/csi-pvc"
  Normal  ProvisioningSucceeded   49s                hostpath.csi.k8s.io_csi-hostpathplugin-0_a9a3cc54-1f3f-4f2c-9304-0cfe731945b6  Successfully provisioned volume pvc-561aca0d-a67b-4cb1-81c3-791b5c654423
  Normal  VolumeModify            25s                external-resizer hostpath.csi.k8s.io                                           external resizer is modifying volume csi-pvc
  Normal  VolumeModifySuccessful  25s                external-resizer hostpath.csi.k8s.io                                           external resizer modified volume csi-pvc successfully

```
8. Create a new VAC named ``gold`` and apply
```
apiVersion: storage.k8s.io/v1alpha1
kind: VolumeAttributesClass
metadata:
  name: gold
driverName: hostpath.csi.k8s.io
parameters:
  provisioned-iops: "8000"
```
10. Modify the pvc with ``kubectl edit pvc csi-pvc`` and add ``volumeAttributesClassName: gold`` to the pvc
11. Verify it is successful:

```
csi-driver-host-path git:(testModifyVolume) ✗ k describe pvc                                         
Name:          csi-pvc
Namespace:     default
StorageClass:  csi-hostpath-sc
Status:        Bound
Volume:        pvc-561aca0d-a67b-4cb1-81c3-791b5c654423
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: hostpath.csi.k8s.io
               volume.kubernetes.io/storage-provisioner: hostpath.csi.k8s.io
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       my-csi-app
Events:
  Type    Reason                  Age                  From                                                                           Message
  ----    ------                  ----                 ----                                                                           -------
  Normal  ExternalProvisioning    42m (x2 over 42m)    persistentvolume-controller                                                    Waiting for a volume to be created either by the external provisioner 'hostpath.csi.k8s.io' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  Provisioning            42m                  hostpath.csi.k8s.io_csi-hostpathplugin-0_a9a3cc54-1f3f-4f2c-9304-0cfe731945b6  External provisioner is provisioning volume for claim "default/csi-pvc"
  Normal  ProvisioningSucceeded   42m                  hostpath.csi.k8s.io_csi-hostpathplugin-0_a9a3cc54-1f3f-4f2c-9304-0cfe731945b6  Successfully provisioned volume pvc-561aca0d-a67b-4cb1-81c3-791b5c654423
  Normal  VolumeModify            3m42s (x2 over 42m)  external-resizer hostpath.csi.k8s.io                                           external resizer is modifying volume csi-pvc
  Normal  VolumeModifySuccessful  3m42s (x2 over 42m)  external-resizer hostpath.csi.k8s.io                                           external resizer modified volume csi-pvc successfully


csi-driver-host-path git:(testModifyVolume) ✗ k get pvc
NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      VOLUMEATTRIBUTESCLASS   AGE
csi-pvc   Bound    pvc-561aca0d-a67b-4cb1-81c3-791b5c654423   1Gi        RWO            csi-hostpath-sc   gold                    42m
```
***Negative Test Cases***
1. The feature gate is enabled in k8s and enable-controller-modify-volume in hostpath driver is set to false, I got the error case:

```
csi-driver-host-path git:(testModifyVolume) ✗ k describe pvc
Name:          csi-pvc
Namespace:     default
StorageClass:  csi-hostpath-sc
Status:        Bound
Volume:        pvc-4bb1d1e5-f3d2-47ee-af83-05ee0430de61
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: hostpath.csi.k8s.io
               volume.kubernetes.io/storage-provisioner: hostpath.csi.k8s.io
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       my-csi-app
Conditions:
  Type                Status  LastProbeTime                     LastTransitionTime                Reason  Message
  ----                ------  -----------------                 ------------------                ------  -------
  ModifyVolumeError   True    Mon, 01 Jan 0001 00:00:00 +0000   Wed, 24 Jan 2024 00:00:17 +0000           ModifyVolume failed with error: rpc error: code = Unimplemented desc = unknown method ControllerModifyVolume for service csi.v1.Controller. Waiting for retry.
Events:
  Type     Reason                 Age                    From                                                                           Message
  ----     ------                 ----                   ----                                                                           -------
  Normal   Provisioning           7m13s                  hostpath.csi.k8s.io_csi-hostpathplugin-0_cd7172db-b406-43bf-8278-c5740f369279  External provisioner is provisioning volume for claim "default/csi-pvc"
  Normal   ExternalProvisioning   7m13s (x2 over 7m13s)  persistentvolume-controller                                                    Waiting for a volume to be created either by the external provisioner 'hostpath.csi.k8s.io' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal   ProvisioningSucceeded  7m13s                  hostpath.csi.k8s.io_csi-hostpathplugin-0_cd7172db-b406-43bf-8278-c5740f369279  Successfully provisioned volume pvc-4bb1d1e5-f3d2-47ee-af83-05ee0430de61
  Normal   VolumeModify           2m27s (x9 over 6m42s)  external-resizer hostpath.csi.k8s.io                                           external resizer is modifying volume csi-pvc
  Warning  VolumeModifyFailed     2m27s (x9 over 6m42s)  external-resizer hostpath.csi.k8s.io                                           rpc error: code = Unimplemented desc = unknown method ControllerModifyVolume
```

2. The feature gate is disabled in k8s and external-resizer(remove feature gate setting in [this commit](https://github.com/kubernetes-csi/csi-driver-host-path/compare/master...sunnylovestiramisu:csi-driver-host-path:testModifyVolume)), starting the csi-driver-host-path

Verify in the log via ``k logs csi-hostpathplugin-0 csi-resizer``, and the log print out:

```
I0124 19:48:04.652450       1 main.go:108] "Version" version="66ff3280dd401e4ed84dbce9b981a08ca69f22cc"
I0124 19:48:04.652552       1 feature_gate.go:249] feature gates: &{map[]}
I0124 19:48:04.654874       1 connection.go:215] Connecting to unix:///csi/csi.sock
I0124 19:48:04.656828       1 common.go:138] Probing CSI driver for readiness
I0124 19:48:04.656856       1 connection.go:244] GRPC call: /csi.v1.Identity/Probe
I0124 19:48:04.656864       1 connection.go:245] GRPC request: {}
I0124 19:48:04.660521       1 connection.go:251] GRPC response: {}
I0124 19:48:04.660597       1 connection.go:252] GRPC error: <nil>
I0124 19:48:04.660642       1 connection.go:244] GRPC call: /csi.v1.Identity/GetPluginInfo
I0124 19:48:04.660726       1 connection.go:245] GRPC request: {}
I0124 19:48:04.661739       1 connection.go:251] GRPC response: {"name":"hostpath.csi.k8s.io","vendor_version":"61b168ca726c91a9e025a8af8533e18453639f71"}
I0124 19:48:04.661758       1 connection.go:252] GRPC error: <nil>
I0124 19:48:04.661777       1 main.go:161] "CSI driver name" driverName="hostpath.csi.k8s.io"
I0124 19:48:04.661793       1 connection.go:244] GRPC call: /csi.v1.Identity/GetPluginCapabilities
I0124 19:48:04.661801       1 connection.go:245] GRPC request: {}
I0124 19:48:04.663366       1 connection.go:251] GRPC response: {"capabilities":[{"Type":{"Service":{"type":1}}},{"Type":{"Service":{"type":3}}},{"Type":{"Service":{"type":2}}}]}
I0124 19:48:04.663439       1 connection.go:252] GRPC error: <nil>
I0124 19:48:04.663521       1 connection.go:244] GRPC call: /csi.v1.Controller/ControllerGetCapabilities
I0124 19:48:04.663558       1 connection.go:245] GRPC request: {}
I0124 19:48:04.665109       1 connection.go:251] GRPC response: {"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":12}}},{"Type":{"Rpc":{"type":4}}},{"Type":{"Rpc":{"type":5}}},{"Type":{"Rpc":{"type":6}}},{"Type":{"Rpc":{"type":3}}},{"Type":{"Rpc":{"type":7}}},{"Type":{"Rpc":{"type":11}}},{"Type":{"Rpc":{"type":13}}},{"Type":{"Rpc":{"type":9}}},{"Type":{"Rpc":{"type":14}}}]}
I0124 19:48:04.665159       1 connection.go:252] GRPC error: <nil>
I0124 19:48:04.665211       1 connection.go:244] GRPC call: /csi.v1.Controller/ControllerGetCapabilities
I0124 19:48:04.665257       1 connection.go:245] GRPC request: {}
I0124 19:48:04.666352       1 connection.go:251] GRPC response: {"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":12}}},{"Type":{"Rpc":{"type":4}}},{"Type":{"Rpc":{"type":5}}},{"Type":{"Rpc":{"type":6}}},{"Type":{"Rpc":{"type":3}}},{"Type":{"Rpc":{"type":7}}},{"Type":{"Rpc":{"type":11}}},{"Type":{"Rpc":{"type":13}}},{"Type":{"Rpc":{"type":9}}},{"Type":{"Rpc":{"type":14}}}]}
I0124 19:48:04.666426       1 connection.go:252] GRPC error: <nil>
I0124 19:48:04.666509       1 main.go:185] "===== Creating csiModifier ====="
I0124 19:48:04.666593       1 csi_modifier.go:39] "===== Creating NewModifierFromClient ====="
I0124 19:48:04.666646       1 connection.go:244] GRPC call: /csi.v1.Controller/ControllerGetCapabilities
I0124 19:48:04.666686       1 connection.go:245] GRPC request: {}
I0124 19:48:04.667733       1 connection.go:251] GRPC response: {"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":12}}},{"Type":{"Rpc":{"type":4}}},{"Type":{"Rpc":{"type":5}}},{"Type":{"Rpc":{"type":6}}},{"Type":{"Rpc":{"type":3}}},{"Type":{"Rpc":{"type":7}}},{"Type":{"Rpc":{"type":11}}},{"Type":{"Rpc":{"type":13}}},{"Type":{"Rpc":{"type":9}}},{"Type":{"Rpc":{"type":14}}}]}
I0124 19:48:04.667816       1 connection.go:252] GRPC error: <nil>
I0124 19:48:04.668037       1 controller.go:120] "Register Pod informer for resizer" controller="hostpath.csi.k8s.io"
I0124 19:48:04.668150       1 main.go:218] "===== Check if VolumeAttributesClass is Enabled ====="
I0124 19:48:04.668262       1 controller.go:243] "Starting external resizer" controller="hostpath.csi.k8s.io"
I0124 19:48:04.668459       1 reflector.go:289] Starting reflector *v1.PersistentVolumeClaim (10m0s) from k8s.io/client-go/informers/factory.go:159
I0124 19:48:04.668485       1 reflector.go:325] Listing and watching *v1.PersistentVolumeClaim from k8s.io/client-go/informers/factory.go:159
I0124 19:48:04.668462       1 reflector.go:289] Starting reflector *v1.Pod (10m0s) from k8s.io/client-go/informers/factory.go:159
I0124 19:48:04.668574       1 reflector.go:325] Listing and watching *v1.Pod from k8s.io/client-go/informers/factory.go:159
I0124 19:48:04.668764       1 reflector.go:289] Starting reflector *v1.PersistentVolume (10m0s) from k8s.io/client-go/informers/factory.go:159
I0124 19:48:04.668818       1 reflector.go:325] Listing and watching *v1.PersistentVolume from k8s.io/client-go/informers/factory.go:159
I0124 19:48:04.679786       1 reflector.go:351] Caches populated for *v1.PersistentVolumeClaim from k8s.io/client-go/informers/factory.go:159
I0124 19:48:04.680732       1 reflector.go:351] Caches populated for *v1.PersistentVolume from k8s.io/client-go/informers/factory.go:159
I0124 19:48:04.705037       1 reflector.go:351] Caches populated for *v1.Pod from k8s.io/client-go/informers/factory.go:159
```

The ``===== Check if VolumeAttributesClass is Enabled =====`` shows that VAC is not enabled and the resizer is up and running without initializing the modify controller, please see the logs print out setting [here](https://github.com/kubernetes-csi/external-resizer/commit/0c2baa574fb199a058655743157ac643db27727a).

**Does this PR introduce a user-facing change?**:

```release-note
Add Modify Volume Support for VolumeAttributesClass, this requires:
1. The feature gate VolumeAttributesClass and API to be enabled in Kubernetes cluster
2. The feature gate VolumeAttributesClass feature gate enabled in external-resizer
```



