### PR TITLE
resizer does not depend on informer

### DIFF
--- a/cmd/csi-resizer/main.go
+++ b/cmd/csi-resizer/main.go
@@ -155,7 +155,6 @@ func main() {
 		csiClient,
 		*timeout,
 		kubeClient,
-		informerFactory,
 		driverName)
 	if err != nil {
 		klog.Fatal(err.Error())

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -233,7 +233,7 @@ func TestController(t *testing.T) {
 		pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 		podInformer := informerFactory.Core().V1().Pods()
 
-		csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+		csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, driverName)
 		if err != nil {
 			t.Fatalf("Test %s: Unable to create resizer: %v", test.Name, err)
 		}
@@ -365,7 +365,7 @@ func TestResizePVC(t *testing.T) {
 		pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 		podInformer := informerFactory.Core().V1().Pods()
 
-		csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+		csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, driverName)
 		if err != nil {
 			t.Fatalf("Test %s: Unable to create resizer: %v", test.Name, err)
 		}

--- a/pkg/controller/expand_and_recover_test.go
+++ b/pkg/controller/expand_and_recover_test.go
@@ -118,7 +118,7 @@ func TestExpandAndRecover(t *testing.T) {
 
 			kubeClient, informerFactory := fakeK8s(initialObjects)
 
-			csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, driverName)
 			if err != nil {
 				t.Fatalf("Test %s: Unable to create resizer: %v", test.name, err)
 			}

--- a/pkg/controller/resize_status_test.go
+++ b/pkg/controller/resize_status_test.go
@@ -86,7 +86,7 @@ func TestResizeFunctions(t *testing.T) {
 
 			kubeClient, informerFactory := fakeK8s(initialObjects)
 
-			csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			csiResizer, err := resizer.NewResizerFromClient(client, 15*time.Second, kubeClient, driverName)
 			if err != nil {
 				t.Fatalf("Test %s: Unable to create resizer: %v", test.name, err)
 			}

--- a/pkg/resizer/csi_resizer.go
+++ b/pkg/resizer/csi_resizer.go
@@ -31,7 +31,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/klog/v2"
@@ -46,7 +45,6 @@ func NewResizerFromClient(
 	csiClient csi.Client,
 	timeout time.Duration,
 	k8sClient kubernetes.Interface,
-	informerFactory informers.SharedInformerFactory,
 	driverName string) (Resizer, error) {
 
 	supportControllerService, err := supportsPluginControllerService(csiClient, timeout)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

resizer does not depend on informer, so remove the parameter.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
