### PR TITLE
Fix modifycontroller nil pointer dereference

### DIFF
--- a/pkg/modifycontroller/controller.go
+++ b/pkg/modifycontroller/controller.go
@@ -156,7 +156,7 @@ func (ctrl *modifyController) updatePVC(oldObj, newObj interface{}) {
 	// 3. PVC is in Bound state
 	oldVacName := oldPVC.Spec.VolumeAttributesClassName
 	newVacName := newPVC.Spec.VolumeAttributesClassName
-	if newVacName != nil && *newVacName != "" && (*newVacName != *oldVacName || oldVacName == nil) && oldPVC.Status.Phase == v1.ClaimBound {
+	if newVacName != nil && *newVacName != "" && (oldVacName == nil || *newVacName != *oldVacName) && oldPVC.Status.Phase == v1.ClaimBound {
 		_, err := ctrl.pvLister.Get(oldPVC.Spec.VolumeName)
 		if err != nil {
 			klog.Errorf("Get PV %q of pvc %q in PVInformer cache failed: %v", oldPVC.Spec.VolumeName, klog.KObj(oldPVC), err)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Today, modifying a volume with no initial `VolumeAttributesClass` will cause the `external-resizer` to restart before modifying the volume due to a nil pointer dereference in `modifycontroller/controller.go`.

Reproduction steps: Follow up to step five of [aws-ebs-csi-driver modify-volume example](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/examples/kubernetes/modify-volume). You will see the following logs in the crashed resizer container: 
[csi-resizer-crash-crashed-pod.txt](https://github.com/kubernetes-csi/external-resizer/files/14483895/csi-resizer-crash-crashed-pod.txt)
[csi-resizer-crash-next-pod.txt](https://github.com/kubernetes-csi/external-resizer/files/14483896/csi-resizer-crash-next-pod.txt)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**: 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed external-resizer crash when modifying volume with no previous volume attributes class
```
