### PR TITLE
Skip modifying volumes owned by other CSI drivers

### DIFF
--- a/pkg/modifycontroller/controller.go
+++ b/pkg/modifycontroller/controller.go
@@ -277,8 +277,9 @@ func (ctrl *modifyController) syncPVC(key string) error {
 	// Only trigger modify volume if the following conditions are met
 	// 1. Non empty vac name
 	// 2. PVC is in Bound state
+	// 3. PV CSI driver name matches local driver
 	vacName := pvc.Spec.VolumeAttributesClassName
-	if vacName != nil && *vacName != "" && pvc.Status.Phase == v1.ClaimBound {
+	if vacName != nil && *vacName != "" && pvc.Status.Phase == v1.ClaimBound && pv.Spec.CSI.Driver == ctrl.name {
 		_, _, err, _ := ctrl.modify(pvc, pv)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes issue (3) from https://github.com/kubernetes/kubernetes/pull/124151#issuecomment-2152647568 - Today, the `external-resizer` will attempt to modify _any_ PVC awaiting modification without checking for if it matches the local CSI driver.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:

No test exercises `syncPVC`, so I could not update the tests for this case. I have manually tested the change against multiple drivers.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug causing external-resizer to attempt to modify volumes owned by other CSI drivers
```
