### PR TITLE
Add extra-modify-metadata flag to external-resizer sidecar

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -211,7 +211,7 @@ func TestController(t *testing.T) {
 			disableVolumeInUseErrorHandler: true,
 		},
 	} {
-		client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true)
+		client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true, false)
 		driverName, _ := client.GetDriverName(context.TODO())
 
 		var expectedCap resource.Quantity
@@ -380,7 +380,7 @@ func TestResizePVC(t *testing.T) {
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true)
+			client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true, false)
 			if test.expansionError != nil {
 				client.SetExpansionError(test.expansionError)
 			}

--- a/pkg/controller/expand_and_recover_test.go
+++ b/pkg/controller/expand_and_recover_test.go
@@ -153,7 +153,7 @@ func TestExpandAndRecover(t *testing.T) {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, true)
-			client := csi.NewMockClient("foo", !test.disableNodeExpansion, !test.disableControllerExpansion, false, true, true)
+			client := csi.NewMockClient("foo", !test.disableNodeExpansion, !test.disableControllerExpansion, false, true, true, false)
 			driverName, _ := client.GetDriverName(context.TODO())
 			if test.expansionError != nil {
 				client.SetExpansionError(test.expansionError)

--- a/pkg/controller/resize_status_test.go
+++ b/pkg/controller/resize_status_test.go
@@ -77,7 +77,7 @@ func TestResizeFunctions(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, true)
-			client := csi.NewMockClient("foo", true, true, false, true, true)
+			client := csi.NewMockClient("foo", true, true, false, true, true, false)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			pvc := test.pvc

--- a/pkg/csi/mock_client.go
+++ b/pkg/csi/mock_client.go
@@ -15,7 +15,9 @@ func NewMockClient(
 	supportsControllerResize bool,
 	supportsControllerModify bool,
 	supportsPluginControllerService bool,
-	supportsControllerSingleNodeMultiWriter bool) *MockClient {
+	supportsControllerSingleNodeMultiWriter bool,
+	supportsExtraModifyMetada bool,
+) *MockClient {
 	return &MockClient{
 		name:                                    name,
 		supportsNodeResize:                      supportsNodeResize,
@@ -23,6 +25,7 @@ func NewMockClient(
 		supportsControllerModify:                supportsControllerModify,
 		supportsPluginControllerService:         supportsPluginControllerService,
 		supportsControllerSingleNodeMultiWriter: supportsControllerSingleNodeMultiWriter,
+		extraModifyMetadata:                     supportsExtraModifyMetada,
 	}
 }
 
@@ -40,6 +43,7 @@ type MockClient struct {
 	checkMigratedLabel                      bool
 	usedSecrets                             atomic.Pointer[map[string]string]
 	usedCapability                          atomic.Pointer[csi.VolumeCapability]
+	extraModifyMetadata                     bool
 }
 
 func (c *MockClient) GetDriverName(context.Context) (string, error) {

--- a/pkg/modifier/csi_modifier.go
+++ b/pkg/modifier/csi_modifier.go
@@ -33,6 +33,7 @@ func NewModifierFromClient(
 	timeout time.Duration,
 	k8sClient kubernetes.Interface,
 	informerFactory informers.SharedInformerFactory,
+	extraModifyMetadata bool,
 	driverName string) (Modifier, error) {
 
 	_, err := supportsControllerModify(csiClient, timeout)
@@ -41,18 +42,20 @@ func NewModifierFromClient(
 	}
 
 	return &csiModifier{
-		name:    driverName,
-		client:  csiClient,
-		timeout: timeout,
+		name:                driverName,
+		client:              csiClient,
+		timeout:             timeout,
+		extraModifyMetadata: extraModifyMetadata,
 
 		k8sClient: k8sClient,
 	}, nil
 }
 
 type csiModifier struct {
-	name    string
-	client  csi.Client
-	timeout time.Duration
+	name                string
+	client              csi.Client
+	timeout             time.Duration
+	extraModifyMetadata bool
 
 	k8sClient kubernetes.Interface
 }

--- a/pkg/modifier/csi_modifier_test.go
+++ b/pkg/modifier/csi_modifier_test.go
@@ -28,10 +28,10 @@ func TestNewModifier(t *testing.T) {
 			SupportsControllerModify: false,
 		},
 	} {
-		client := csi.NewMockClient("mock", false, false, c.SupportsControllerModify, false, false)
+		client := csi.NewMockClient("mock", false, false, c.SupportsControllerModify, false, false, false)
 		driverName := "mock-driver"
 		k8sClient, informerFactory := fakeK8s()
-		_, err := NewModifierFromClient(client, 0, k8sClient, informerFactory, driverName)
+		_, err := NewModifierFromClient(client, 0, k8sClient, informerFactory, false, driverName)
 		if err != c.Error {
 			t.Errorf("Case %d: Unexpected error: wanted %v, got %v", i, c.Error, err)
 		}

--- a/pkg/modifycontroller/controller_test.go
+++ b/pkg/modifycontroller/controller_test.go
@@ -61,7 +61,7 @@ func TestController(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Setup
-			client := csi.NewMockClient("foo", true, true, true, true, true)
+			client := csi.NewMockClient("foo", true, true, true, true, true, false)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			var initialObjects []runtime.Object
@@ -78,7 +78,7 @@ func TestController(t *testing.T) {
 			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 			vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
 
-			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
 			if err != nil {
 				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
 			}
@@ -86,7 +86,7 @@ func TestController(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, informerFactory,
+				time.Second, false, informerFactory,
 				workqueue.DefaultControllerRateLimiter())
 
 			ctrlInstance, _ := controller.(*modifyController)
@@ -154,7 +154,7 @@ func TestModifyPVC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := csi.NewMockClient("mock", true, true, true, true, true)
+			client := csi.NewMockClient("mock", true, true, true, true, true, false)
 			if test.modifyFailure {
 				client.SetModifyFailed()
 			}
@@ -179,7 +179,7 @@ func TestModifyPVC(t *testing.T) {
 			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 			vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
 
-			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
 			if err != nil {
 				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
 			}
@@ -187,7 +187,7 @@ func TestModifyPVC(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, informerFactory,
+				time.Second, false, informerFactory,
 				workqueue.DefaultControllerRateLimiter())
 
 			ctrlInstance, _ := controller.(*modifyController)

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -102,7 +102,7 @@ func TestMarkControllerModifyVolumeStatus(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			client := csi.NewMockClient("foo", true, true, true, true, true)
+			client := csi.NewMockClient("foo", true, true, true, true, true, false)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			pvc := test.pvc
@@ -112,13 +112,13 @@ func TestMarkControllerModifyVolumeStatus(t *testing.T) {
 
 			kubeClient, informerFactory := fakeK8s(initialObjects)
 
-			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
 			if err != nil {
 				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
 			}
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, informerFactory,
+				time.Second, false, informerFactory,
 				workqueue.DefaultControllerRateLimiter())
 
 			ctrlInstance, _ := controller.(*modifyController)
@@ -162,7 +162,7 @@ func TestUpdateConditionBasedOnError(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			client := csi.NewMockClient("foo", true, true, true, true, true)
+			client := csi.NewMockClient("foo", true, true, true, true, true, false)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			pvc := test.pvc
@@ -172,13 +172,13 @@ func TestUpdateConditionBasedOnError(t *testing.T) {
 
 			kubeClient, informerFactory := fakeK8s(initialObjects)
 
-			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
 			if err != nil {
 				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
 			}
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, informerFactory,
+				time.Second, false, informerFactory,
 				workqueue.DefaultControllerRateLimiter())
 
 			ctrlInstance, _ := controller.(*modifyController)
@@ -231,7 +231,7 @@ func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			client := csi.NewMockClient("foo", true, true, true, true, true)
+			client := csi.NewMockClient("foo", true, true, true, true, true, false)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			var initialObjects []runtime.Object
@@ -240,13 +240,13 @@ func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
 
 			kubeClient, informerFactory := fakeK8s(initialObjects)
 
-			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
 			if err != nil {
 				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
 			}
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, informerFactory,
+				time.Second, false, informerFactory,
 				workqueue.DefaultControllerRateLimiter())
 
 			ctrlInstance, _ := controller.(*modifyController)
@@ -293,7 +293,7 @@ func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			client := csi.NewMockClient("foo", true, true, true, true, true)
+			client := csi.NewMockClient("foo", true, true, true, true, true, false)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			var initialObjects []runtime.Object
@@ -306,13 +306,13 @@ func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
 			podInformer := informerFactory.Core().V1().Pods()
 			vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
 
-			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
+			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
 			if err != nil {
 				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
 			}
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, informerFactory,
+				time.Second, false, informerFactory,
 				workqueue.DefaultControllerRateLimiter())
 
 			ctrlInstance, _ := controller.(*modifyController)

--- a/pkg/modifycontroller/modify_volume.go
+++ b/pkg/modifycontroller/modify_volume.go
@@ -28,6 +28,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	pvcNameKey      = "csi.storage.k8s.io/pvc/name"
+	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
+	pvNameKey       = "csi.storage.k8s.io/pv/name"
+)
+
 // The return value bool is only used as a sentinel value when function returns without actually performing modification
 func (ctrl *modifyController) modify(pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error, bool) {
 	pvcSpecVacName := pvc.Spec.VolumeAttributesClassName
@@ -148,6 +154,11 @@ func (ctrl *modifyController) callModifyVolumeOnPlugin(
 	pvc *v1.PersistentVolumeClaim,
 	pv *v1.PersistentVolume,
 	vac *storagev1beta1.VolumeAttributesClass) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
+	if ctrl.extraModifyMetadata {
+		vac.Parameters[pvcNameKey] = pvc.GetName()
+		vac.Parameters[pvcNamespaceKey] = pvc.GetNamespace()
+		vac.Parameters[pvNameKey] = pv.GetName()
+	}
 	err := ctrl.modifier.Modify(pv, vac.Parameters)
 
 	if err != nil {

--- a/pkg/resizer/csi_resizer_test.go
+++ b/pkg/resizer/csi_resizer_test.go
@@ -72,7 +72,7 @@ func TestNewResizer(t *testing.T) {
 			Error: resizeNotSupportErr,
 		},
 	} {
-		client := csi.NewMockClient("mock", c.SupportsNodeResize, c.SupportsControllerResize, false, c.SupportsPluginControllerService, c.SupportsControllerSingleNodeMultiWriter)
+		client := csi.NewMockClient("mock", c.SupportsNodeResize, c.SupportsControllerResize, false, c.SupportsPluginControllerService, c.SupportsControllerSingleNodeMultiWriter, false)
 		driverName := "mock-driver"
 		k8sClient := fake.NewSimpleClientset()
 		resizer, err := NewResizerFromClient(client, 0, k8sClient, driverName)
@@ -106,7 +106,7 @@ func TestResizeWithSecret(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		client := csi.NewMockClient("mock", true, true, false, true, true)
+		client := csi.NewMockClient("mock", true, true, false, true, true, false)
 		secret := makeSecret("some-secret", "secret-namespace")
 		k8sClient := fake.NewSimpleClientset(secret)
 		pv := makeTestPV("test-csi", 2, "ebs-csi", "vol-abcde", tc.hasExpansionSecret)
@@ -164,7 +164,7 @@ func TestResizeMigratedPV(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			driverName := tc.driverName
-			client := csi.NewMockClient(driverName, true, true, false, true, true)
+			client := csi.NewMockClient(driverName, true, true, false, true, true, false)
 			client.SetCheckMigratedLabel()
 			k8sClient := fake.NewSimpleClientset()
 			resizer, err := NewResizerFromClient(client, 0, k8sClient, driverName)
@@ -433,7 +433,7 @@ func TestCanSupport(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			driverName := tc.driverName
-			client := csi.NewMockClient(driverName, true, true, false, true, true)
+			client := csi.NewMockClient(driverName, true, true, false, true, true, false)
 			k8sClient := fake.NewSimpleClientset()
 			resizer, err := NewResizerFromClient(client, 0, k8sClient, driverName)
 			if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds a flag that can be set by the user which will inject extra PVC and PV metadata as parameters when calling ModifyVolume on CSI Drivers. This will enable CSI Drivers to support StorageClass parameters that depend on the extra metadata in modification via VolumeAttributesClass as well. 

See [doc](https://docs.google.com/document/d/1SI8RDwNmzyaWtgaoglqQ3ydfye_6Vwy_EF1rVdaHQb8/edit?usp=sharing) for more info

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:

```release-note
Adds the flag --extra-modify-metadata, which when set to true, will inject extra PVC and PV metadata as parameters when calling ModifyVolume on CSI Drivers
```
