### PR TITLE
Changelog for v1.11.2

### DIFF
--- a/CHANGELOG/CHANGELOG-1.11.md
+++ b/CHANGELOG/CHANGELOG-1.11.md
@@ -1,3 +1,25 @@
+# Release notes for v1.11.2
+
+[Documentation](https://kubernetes-csi.github.io)
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Clear modify status of a pvc when the modification operation is completed ([#423](https://github.com/kubernetes-csi/external-resizer/pull/423), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+- Ensure external-resizer does not modify volumes owned by other CSI drivers ([#422](https://github.com/kubernetes-csi/external-resizer/pull/422), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
 # Release notes for v1.11.1
 
 [Documentation](https://kubernetes-csi.github.io)


### PR DESCRIPTION
```release-note
NONE
```

Release Process checklist from https://github.com/kubernetes-csi/external-resizer/blob/master/release-tools/SIDECAR_RELEASE_PROCESS.md#release-process:

1. PRs all resolved
2. No dependency upgrades in this release
3. Canaries on master look green: https://testgrid.k8s.io/sig-storage-csi-ci
4. Post-external-resizer-push-images looks green: https://testgrid.k8s.io/sig-storage-image-build#post-external-resizer-push-images
5. Release notes generated
6. I don't think we need PR for README changes because resizer feature gate for VAC still alpha. 

---

Steps left:
7. Ensure no PRS will merge
8. Create a new release following a previous release as a template. 
9. N/A
10. Check [image build status](https://testgrid.k8s.io/sig-storage-image-build).
11. Promote images from k8s-staging-sig-storage to registry.k8s.io/sig-storage. From the [k8s image repo](https://github.com/kubernetes/k8s.io/tree/HEAD/registry.k8s.io/images/k8s-staging-sig-storage), run ./generate.sh > images.yaml, and send a PR with the updated images. Once merged, the image promoter will copy the images from staging to prod.
12. Update [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs) sidecar and feature pages with the new released version.
13. Update CSI hostpath driver with the new sidecars in the [CSI repo](https://github.com/kubernetes-csi/csi-driver-host-path/tree/HEAD/deploy) and [k/k in-tree](https://github.com/kubernetes/kubernetes/tree/HEAD/test/e2e/testing-manifests/storage-csi/hostpath/hostpath)
