### PR TITLE
[WIP DO NOT MERGE] AIO Refactor Draft

### DIFF
--- a/pkg/aioresizer/aioresizer.go
+++ b/pkg/aioresizer/aioresizer.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO: Obviously "aioresizer" a horrible name but I couldn't think of a better one
+package aioresizer
+
+import (
+	"context"
+	"time"
+
+	"github.com/kubernetes-csi/external-resizer/pkg/controller"
+	"github.com/kubernetes-csi/external-resizer/pkg/csi"
+	"github.com/kubernetes-csi/external-resizer/pkg/features"
+	"github.com/kubernetes-csi/external-resizer/pkg/modifier"
+	"github.com/kubernetes-csi/external-resizer/pkg/modifycontroller"
+	extresizer "github.com/kubernetes-csi/external-resizer/pkg/resizer"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/workqueue"
+	csitrans "k8s.io/csi-translation-lib"
+	"k8s.io/klog/v2"
+)
+
+const version = "unknown"
+
+type ResizerOptions struct {
+	// CLI options
+	OperationTimeout       time.Duration
+	RetryIntervalStart     time.Duration
+	RetryIntervalMax       time.Duration
+	ResyncPeriod           time.Duration
+	HandleVolumeInUseError bool
+	Workers                int
+
+	// Derived options (Kubernetes config, etc)
+	DriverName string
+
+	// Shared objects (clients, informers, etc)
+	Client     kubernetes.Interface
+	Factory    informers.SharedInformerFactory
+	CSIClient  csi.Client
+	Translator csitrans.CSITranslator
+}
+
+type AIOResizer interface {
+	Run(ctx context.Context)
+	GetVersion() string
+}
+
+type resizer struct {
+	options          ResizerOptions
+	csiResizer       extresizer.Resizer
+	csiModifier      modifier.Modifier
+	resizeController controller.ResizeController
+	modifyController modifycontroller.ModifyController
+}
+
+func (r *resizer) Run(ctx context.Context) {
+	r.options.Factory.Start(wait.NeverStop)
+	go r.resizeController.Run(r.options.Workers, ctx)
+	if utilfeature.DefaultFeatureGate.Enabled(features.VolumeAttributesClass) {
+		go r.modifyController.Run(r.options.Workers, ctx)
+	}
+	<-ctx.Done()
+}
+
+func (r *resizer) GetVersion() string {
+	return version
+}
+
+func NewAIOResizer(options ResizerOptions) (AIOResizer, string) {
+	var err error
+	r := &resizer{
+		options: options,
+	}
+
+	r.csiResizer, err = extresizer.NewResizerFromClient(
+		options.CSIClient,
+		options.OperationTimeout,
+		options.Client,
+		options.DriverName)
+	if err != nil {
+		klog.ErrorS(err, "Failed to create CSI resizer")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
+
+	r.csiModifier, err = modifier.NewModifierFromClient(
+		options.CSIClient,
+		options.OperationTimeout,
+		options.Client,
+		options.Factory,
+		options.DriverName)
+	if err != nil {
+		klog.ErrorS(err, "Failed to create CSI modifier")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
+
+	resizerName := r.csiResizer.Name()
+	r.resizeController = controller.NewResizeController(resizerName, r.csiResizer, options.Client, options.ResyncPeriod, options.Factory,
+		workqueue.NewItemExponentialFailureRateLimiter(options.RetryIntervalStart, options.RetryIntervalMax),
+		options.HandleVolumeInUseError)
+	modifierName := r.csiModifier.Name()
+	// Add modify controller only if the feature gate is enabled
+	if utilfeature.DefaultFeatureGate.Enabled(features.VolumeAttributesClass) {
+		r.modifyController = modifycontroller.NewModifyController(modifierName, r.csiModifier, options.Client, options.ResyncPeriod, options.Factory,
+			workqueue.NewItemExponentialFailureRateLimiter(options.RetryIntervalStart, options.RetryIntervalMax))
+	}
+
+	return r, resizerName
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

Notes from slack:

```
The sidecars do a lot of "business logic" initialization in their `main.go`s we need to factor out. This is the primary goal I had with my refactoring. Right now, I put the logic in its own package but thought needed on where it should go long term (try to merge into controller packages? leave in its own package? put it in `cmd`?)

There are some things that the `main.go` does that should be done common across all sidecars, specifically:

* Setting up CLI flags and logging
* Creating Kubernetes client (I originally wanted to just pass the config into the sidecar and have it construct its own clients, but that's not possible because `main.go` needs the client to construct informers and similar)
* CSI metrics manager and CSI translator (need to double check these can be safely shared across sidecars)
* HTTP server for profiling and metrics
* Informer factory(s)
* GRPC connection (annoyingly, the resizer has its own library wrapping this, on my todo list to fix)
```
