### PR TITLE
Bump release tools

### DIFF
--- a/release-tools/.github/dependabot.yaml
+++ b/release-tools/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "daily"
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10

--- a/release-tools/.github/workflows/codespell.yml
+++ b/release-tools/.github/workflows/codespell.yml
@@ -1,0 +1,15 @@
+# GitHub Action to automate the identification of common misspellings in text files.
+# https://github.com/codespell-project/actions-codespell
+# https://github.com/codespell-project/codespell
+name: codespell
+on: [push, pull_request]
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          skip: "*.png,*.jpg,*.svg,*.sum,./.git,./.github/workflows/codespell.yml,./prow.sh"

--- a/release-tools/.github/workflows/trivy.yaml
+++ b/release-tools/.github/workflows/trivy.yaml
@@ -1,0 +1,29 @@
+name: Run Trivy scanner for Go version vulnerabilities
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  trivy:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get Go version
+        id: go-version
+        run: |
+          GO_VERSION=$(cat prow.sh  | grep "configvar CSI_PROW_GO_VERSION_BUILD" | awk '{print $3}' | sed 's/"//g')
+          echo "version=$GO_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Run Trivy scanner for Go version vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'golang:${{ steps.go-version.outputs.version }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'library'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -84,7 +84,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
     1. Compare the generated output to the new commits for the release to check if
        any notable change missed a release note.
     1. Reword release notes as needed, ideally in the original PRs so that the
-       release notes can be regnerated. Make sure to check notes for breaking
+       release notes can be regenerated. Make sure to check notes for breaking
        changes and deprecations.
     1. If release is a new major/minor version, create a new `CHANGELOG-<major>.<minor>.md`
        file.

--- a/release-tools/generate-patch-release-notes.sh
+++ b/release-tools/generate-patch-release-notes.sh
@@ -23,13 +23,17 @@
 # CSI_RELEASE_TOKEN: Github token needed for generating release notes
 # GITHUB_USER: Github username to create PRs with
 #
+# Required tools:
+# - gh
+# - release-notes (https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md)
+# 
 # Instructions:
-# 1. Login with "gh auth login"
-# 2. Copy this script to the kubernetes-csi directory (one directory above the
-# repos)
-# 3. Update the repos and versions in the $releases array
-# 4. Set environment variables
-# 5. Run script from the kubernetes-csi directory
+# 1. Install the required tools
+# 2. Login with "gh auth login"
+# 3. Copy this script to the kubernetes-csi directory (one directory above the repos)
+# 4. Update the repos and versions in the $releases array
+# 5. Set environment variables
+# 6. Run script from the kubernetes-csi directory
 #
 # Caveats:
 # - This script doesn't handle regenerating and updating existing PRs yet.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Bump release-tools to get go 1.22.5 to CI.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
