### PR TITLE
Bump VAC objects to v1beta1

### DIFF
--- a/pkg/modifycontroller/controller.go
+++ b/pkg/modifycontroller/controller.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	storagev1alpha1listers "k8s.io/client-go/listers/storage/v1alpha1"
+	storagev1beta1listers "k8s.io/client-go/listers/storage/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -56,7 +56,7 @@ type modifyController struct {
 	pvListerSynced  cache.InformerSynced
 	pvcLister       corelisters.PersistentVolumeClaimLister
 	pvcListerSynced cache.InformerSynced
-	vacLister       storagev1alpha1listers.VolumeAttributesClassLister
+	vacLister       storagev1beta1listers.VolumeAttributesClassLister
 	vacListerSynced cache.InformerSynced
 	// the key of the map is {PVC_NAMESPACE}/{PVC_NAME}
 	uncertainPVCs map[string]v1.PersistentVolumeClaim
@@ -72,7 +72,7 @@ func NewModifyController(
 	pvcRateLimiter workqueue.RateLimiter) ModifyController {
 	pvInformer := informerFactory.Core().V1().PersistentVolumes()
 	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
-	vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+	vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events(v1.NamespaceAll)})

--- a/pkg/modifycontroller/controller_test.go
+++ b/pkg/modifycontroller/controller_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kubernetes-csi/external-resizer/pkg/modifier"
 
 	v1 "k8s.io/api/core/v1"
-	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -76,7 +76,7 @@ func TestController(t *testing.T) {
 			kubeClient, informerFactory := fakeK8s(initialObjects)
 			pvInformer := informerFactory.Core().V1().PersistentVolumes()
 			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
-			vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+			vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
 
 			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
 			if err != nil {
@@ -104,7 +104,7 @@ func TestController(t *testing.T) {
 					pvInformer.Informer().GetStore().Add(obj)
 				case *v1.PersistentVolumeClaim:
 					pvcInformer.Informer().GetStore().Add(obj)
-				case *storagev1alpha1.VolumeAttributesClass:
+				case *storagev1beta1.VolumeAttributesClass:
 					vacInformer.Informer().GetStore().Add(obj)
 				default:
 					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)
@@ -177,7 +177,7 @@ func TestModifyPVC(t *testing.T) {
 			kubeClient, informerFactory := fakeK8s(initialObjects)
 			pvInformer := informerFactory.Core().V1().PersistentVolumes()
 			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
-			vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+			vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
 
 			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
 			if err != nil {
@@ -205,7 +205,7 @@ func TestModifyPVC(t *testing.T) {
 					pvInformer.Informer().GetStore().Add(obj)
 				case *v1.PersistentVolumeClaim:
 					pvcInformer.Informer().GetStore().Add(obj)
-				case *storagev1alpha1.VolumeAttributesClass:
+				case *storagev1beta1.VolumeAttributesClass:
 					vacInformer.Informer().GetStore().Add(obj)
 				default:
 					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
-	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -230,7 +230,7 @@ func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
 	for _, test := range tests {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
 			client := csi.NewMockClient("foo", true, true, true, true, true)
 			driverName, _ := client.GetDriverName(context.TODO())
 
@@ -304,7 +304,7 @@ func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
 			pvInformer := informerFactory.Core().V1().PersistentVolumes()
 			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 			podInformer := informerFactory.Core().V1().Pods()
-			vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+			vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
 
 			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
 			if err != nil {
@@ -335,7 +335,7 @@ func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
 					pvcInformer.Informer().GetStore().Add(obj)
 				case *v1.Pod:
 					podInformer.Informer().GetStore().Add(obj)
-				case *storagev1alpha1.VolumeAttributesClass:
+				case *storagev1beta1.VolumeAttributesClass:
 					vacInformer.Informer().GetStore().Add(obj)
 				default:
 					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)

--- a/pkg/modifycontroller/modify_volume.go
+++ b/pkg/modifycontroller/modify_volume.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
-	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -102,7 +102,7 @@ func (ctrl *modifyController) validateVACAndModifyVolumeWithTarget(
 func (ctrl *modifyController) controllerModifyVolumeWithTarget(
 	pvc *v1.PersistentVolumeClaim,
 	pv *v1.PersistentVolume,
-	vacObj *storagev1alpha1.VolumeAttributesClass,
+	vacObj *storagev1beta1.VolumeAttributesClass,
 	pvcSpecVacName *string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error, bool) {
 	var err error
 	pvc, pv, err = ctrl.callModifyVolumeOnPlugin(pvc, pv, vacObj)
@@ -147,7 +147,7 @@ func (ctrl *modifyController) controllerModifyVolumeWithTarget(
 func (ctrl *modifyController) callModifyVolumeOnPlugin(
 	pvc *v1.PersistentVolumeClaim,
 	pv *v1.PersistentVolume,
-	vac *storagev1alpha1.VolumeAttributesClass) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
+	vac *storagev1beta1.VolumeAttributesClass) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
 	err := ctrl.modifier.Modify(pv, vac.Parameters)
 
 	if err != nil {

--- a/pkg/modifycontroller/modify_volume_test.go
+++ b/pkg/modifycontroller/modify_volume_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kubernetes-csi/external-resizer/pkg/features"
 	"github.com/kubernetes-csi/external-resizer/pkg/modifier"
 	v1 "k8s.io/api/core/v1"
-	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,13 +23,13 @@ import (
 )
 
 var (
-	testVacObject = &storagev1alpha1.VolumeAttributesClass{
+	testVacObject = &storagev1beta1.VolumeAttributesClass{
 		ObjectMeta: metav1.ObjectMeta{Name: testVac},
 		DriverName: "test-driver",
 		Parameters: map[string]string{"iops": "3000"},
 	}
 
-	targetVacObject = &storagev1alpha1.VolumeAttributesClass{
+	targetVacObject = &storagev1beta1.VolumeAttributesClass{
 		ObjectMeta: metav1.ObjectMeta{Name: targetVac},
 		DriverName: "test-driver",
 		Parameters: map[string]string{"iops": "4567"},
@@ -103,7 +103,7 @@ func TestModify(t *testing.T) {
 			kubeClient, informerFactory := fakeK8s(initialObjects)
 			pvInformer := informerFactory.Core().V1().PersistentVolumes()
 			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
-			vacInformer := informerFactory.Storage().V1alpha1().VolumeAttributesClasses()
+			vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
 
 			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, driverName)
 			if err != nil {
@@ -125,7 +125,7 @@ func TestModify(t *testing.T) {
 					pvInformer.Informer().GetStore().Add(obj)
 				case *v1.PersistentVolumeClaim:
 					pvcInformer.Informer().GetStore().Add(obj)
-				case *storagev1alpha1.VolumeAttributesClass:
+				case *storagev1beta1.VolumeAttributesClass:
 					vacInformer.Informer().GetStore().Add(obj)
 				default:
 					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Bump VAC and VAC listers to v1beta1

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Upgraded VolumeAttributesClass objects and listers to v1beta1. Action required: If VolumeAttributesClass feature gate gate is enabled, this sidecar may only be used with Kubernetes v1.31.
```