### PR TITLE
Add modifycontroller SyncPVC unit tests

### DIFF
--- a/pkg/modifycontroller/controller.go
+++ b/pkg/modifycontroller/controller.go
@@ -252,7 +252,7 @@ func (ctrl *modifyController) sync() {
 	}
 }
 
-// syncPVC checks if a pvc requests resizing, and execute the resize operation if requested.
+// syncPVC checks if a pvc requests modification, and execute the ModifyVolume operation if requested.
 func (ctrl *modifyController) syncPVC(key string) error {
 	klog.V(4).InfoS("Started PVC processing for modify controller", "key", key)
 
@@ -277,7 +277,7 @@ func (ctrl *modifyController) syncPVC(key string) error {
 	}
 
 	// Only trigger modify volume if the following conditions are met
-	// 1. Non empty vac name
+	// 1. Non-empty vac name
 	// 2. PVC is in Bound state
 	// 3. PV CSI driver name matches local driver
 	vacName := pvc.Spec.VolumeAttributesClassName

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -28,12 +28,14 @@ import (
 const (
 	pvcName      = "foo"
 	pvcNamespace = "modify"
+	pvName       = "testPV"
 )
 
 var (
 	fsVolumeMode           = v1.PersistentVolumeFilesystem
 	testVac                = "test-vac"
 	targetVac              = "target-vac"
+	testDriverName         = "mock"
 	infeasibleErr          = status.Errorf(codes.InvalidArgument, "Parameters in VolumeAttributesClass is invalid")
 	finalErr               = status.Errorf(codes.Internal, "Final error")
 	pvcConditionInProgress = v1.PersistentVolumeClaimCondition{
@@ -390,7 +392,7 @@ func createTestPV(capacityGB int, pvcName, pvcNamespace string, pvcUID types.UID
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{
-					Driver:       "foo",
+					Driver:       testDriverName,
 					VolumeHandle: "foo",
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug


 /kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Add modifycontroller SyncPVC unit tests. Including a retro-active unit test for #422.

Also de-duplicate/document some of the unit test boilerplate to help new contributors understand the code. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

/hold

There are a couple of questions in PR marked `TODO Q`. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
