### PR TITLE
Ensure infeasible PVC modifications are retried at slower pace

### DIFF
--- a/cmd/csi-resizer/main.go
+++ b/cmd/csi-resizer/main.go
@@ -222,7 +222,7 @@ func main() {
 	var mc modifycontroller.ModifyController
 	// Add modify controller only if the feature gate is enabled
 	if utilfeature.DefaultFeatureGate.Enabled(features.VolumeAttributesClass) {
-		mc = modifycontroller.NewModifyController(modifierName, csiModifier, kubeClient, *resyncPeriod, *extraModifyMetadata, informerFactory,
+		mc = modifycontroller.NewModifyController(modifierName, csiModifier, kubeClient, *resyncPeriod, *retryIntervalMax, *extraModifyMetadata, informerFactory,
 			workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax))
 	}
 

--- a/pkg/csi/mock_client.go
+++ b/pkg/csi/mock_client.go
@@ -39,7 +39,7 @@ type MockClient struct {
 	expandCalled                            atomic.Int32
 	modifyCalled                            atomic.Int32
 	expansionError                          error
-	modifyFailed                            bool
+	modifyError                             error
 	checkMigratedLabel                      bool
 	usedSecrets                             atomic.Pointer[map[string]string]
 	usedCapability                          atomic.Pointer[csi.VolumeCapability]
@@ -74,8 +74,8 @@ func (c *MockClient) SetExpansionError(err error) {
 	c.expansionError = err
 }
 
-func (c *MockClient) SetModifyFailed() {
-	c.modifyFailed = true
+func (c *MockClient) SetModifyError(err error) {
+	c.modifyError = err
 }
 
 func (c *MockClient) SetCheckMigratedLabel() {
@@ -135,8 +135,8 @@ func (c *MockClient) Modify(
 	secrets map[string]string,
 	mutableParameters map[string]string) error {
 	c.modifyCalled.Add(1)
-	if c.modifyFailed {
-		return fmt.Errorf("modify failed")
+	if c.modifyError != nil {
+		return c.modifyError
 	}
 	return nil
 }

--- a/pkg/modifycontroller/controller.go
+++ b/pkg/modifycontroller/controller.go
@@ -235,7 +235,7 @@ func (ctrl *modifyController) sync() {
 	}
 }
 
-// syncPVC checks if a pvc requests resizing, and execute the resize operation if requested.
+// syncPVC checks if a pvc requests modification, and execute the ModifyVolume operation if requested.
 func (ctrl *modifyController) syncPVC(key string) error {
 	klog.V(4).InfoS("Started PVC processing for modify controller", "key", key)
 
@@ -260,7 +260,7 @@ func (ctrl *modifyController) syncPVC(key string) error {
 	}
 
 	// Only trigger modify volume if the following conditions are met
-	// 1. Non empty vac name
+	// 1. Non-empty vac name
 	// 2. PVC is in Bound state
 	// 3. PV CSI driver name matches local driver
 	vacName := pvc.Spec.VolumeAttributesClassName

--- a/pkg/modifycontroller/controller_test.go
+++ b/pkg/modifycontroller/controller_test.go
@@ -37,7 +37,7 @@ func TestController(t *testing.T) {
 	}{
 		{
 			name:          "Modify called",
-			pvc:           createTestPVC(pvcName, "target-vac" /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
+			pvc:           createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
 			pv:            basePV,
 			vacExists:     true,
 			callCSIModify: true,
@@ -61,57 +61,13 @@ func TestController(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Setup
-			client := csi.NewMockClient("foo", true, true, true, true, true, false)
-			driverName, _ := client.GetDriverName(context.TODO())
+			client := csi.NewMockClient(testDriverName, true, true, true, true, true, false)
 
-			var initialObjects []runtime.Object
-			initialObjects = append(initialObjects, test.pvc)
-			initialObjects = append(initialObjects, test.pv)
-			// existing vac set in the pvc and pv
-			initialObjects = append(initialObjects, testVacObject)
-			if test.vacExists {
-				initialObjects = append(initialObjects, targetVacObject)
-			}
-
-			kubeClient, informerFactory := fakeK8s(initialObjects)
-			pvInformer := informerFactory.Core().V1().PersistentVolumes()
-			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
-			vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
-
-			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
-			if err != nil {
-				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
-			}
-
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			controller := NewModifyController(driverName,
-				csiModifier, kubeClient,
-				time.Second, false, informerFactory,
-				workqueue.DefaultTypedControllerRateLimiter[string]())
-
-			ctrlInstance, _ := controller.(*modifyController)
-
-			stopCh := make(chan struct{})
-			informerFactory.Start(stopCh)
-
-			ctx := context.TODO()
+			initialObjects := []runtime.Object{test.pvc, test.pv, testVacObject, targetVacObject}
+			ctrlInstance, ctx := setupFakeK8sEnvironment(t, client, initialObjects)
 			defer ctx.Done()
-			go controller.Run(1, ctx)
 
-			for _, obj := range initialObjects {
-				switch obj.(type) {
-				case *v1.PersistentVolume:
-					pvInformer.Informer().GetStore().Add(obj)
-				case *v1.PersistentVolumeClaim:
-					pvcInformer.Informer().GetStore().Add(obj)
-				case *storagev1beta1.VolumeAttributesClass:
-					vacInformer.Informer().GetStore().Add(obj)
-				default:
-					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)
-				}
-			}
-			time.Sleep(time.Second * 2)
-			_, _, err, _ = ctrlInstance.modify(test.pvc, test.pv)
+			_, _, err, _ := ctrlInstance.modify(test.pvc, test.pv)
 			if err != nil {
 				t.Fatalf("for %s: unexpected error: %v", test.name, err)
 			}
@@ -141,14 +97,14 @@ func TestModifyPVC(t *testing.T) {
 	}{
 		{
 			name:          "Modify succeeded",
-			pvc:           createTestPVC(pvcName, "target-vac" /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
+			pvc:           createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
 			pv:            basePV,
 			modifyFailure: false,
 			expectFailure: false,
 		},
 		{
 			name:          "Modify failed",
-			pvc:           createTestPVC(pvcName, "target-vac" /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
+			pvc:           createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
 			pv:            basePV,
 			modifyFailure: true,
 			expectFailure: true,
@@ -157,67 +113,16 @@ func TestModifyPVC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := csi.NewMockClient("mock", true, true, true, true, true, false)
+			client := csi.NewMockClient(testDriverName, true, true, true, true, true, false)
 			if test.modifyFailure {
 				client.SetModifyFailed()
 			}
-			driverName, _ := client.GetDriverName(context.TODO())
 
-			initialObjects := []runtime.Object{}
-			if test.pvc != nil {
-				initialObjects = append(initialObjects, test.pvc)
-			}
-			if test.pv != nil {
-				test.pv.Spec.PersistentVolumeSource.CSI.Driver = driverName
-				initialObjects = append(initialObjects, test.pv)
-			}
-
-			// existing vac set in the pvc and pv
-			initialObjects = append(initialObjects, testVacObject)
-			// new vac used in modify volume
-			initialObjects = append(initialObjects, targetVacObject)
-
-			kubeClient, informerFactory := fakeK8s(initialObjects)
-			pvInformer := informerFactory.Core().V1().PersistentVolumes()
-			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
-			vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
-
-			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
-			if err != nil {
-				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
-			}
-
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			controller := NewModifyController(driverName,
-				csiModifier, kubeClient,
-				time.Second, false, informerFactory,
-				workqueue.DefaultTypedControllerRateLimiter[string]())
-
-			ctrlInstance, _ := controller.(*modifyController)
-
-			stopCh := make(chan struct{})
-			informerFactory.Start(stopCh)
-
-			ctx := context.TODO()
+			initialObjects := []runtime.Object{test.pvc, test.pv, testVacObject, targetVacObject}
+			ctrlInstance, ctx := setupFakeK8sEnvironment(t, client, initialObjects)
 			defer ctx.Done()
-			go controller.Run(1, ctx)
 
-			for _, obj := range initialObjects {
-				switch obj.(type) {
-				case *v1.PersistentVolume:
-					pvInformer.Informer().GetStore().Add(obj)
-				case *v1.PersistentVolumeClaim:
-					pvcInformer.Informer().GetStore().Add(obj)
-				case *storagev1beta1.VolumeAttributesClass:
-					vacInformer.Informer().GetStore().Add(obj)
-				default:
-					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)
-				}
-			}
-
-			time.Sleep(time.Second * 2)
-
-			_, _, err, _ = ctrlInstance.modify(test.pvc, test.pv)
+			_, _, err, _ := ctrlInstance.modify(test.pvc, test.pv)
 
 			if test.expectFailure && err == nil {
 				t.Errorf("for %s expected error got nothing", test.name)
@@ -230,4 +135,130 @@ func TestModifyPVC(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSyncPVC(t *testing.T) {
+	basePVC := createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/)
+	basePV := createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, testVac)
+
+	otherDriverPV := createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, testVac)
+	otherDriverPV.Spec.PersistentVolumeSource.CSI.Driver = "some-other-driver"
+
+	unboundPVC := createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/)
+	unboundPVC.Status.Phase = v1.ClaimPending
+
+	pvcWithUncreatedPV := createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/)
+	pvcWithUncreatedPV.Spec.VolumeName = ""
+
+	tests := []struct {
+		name          string
+		pvc           *v1.PersistentVolumeClaim
+		pv            *v1.PersistentVolume
+		callCSIModify bool
+	}{
+		{
+			name:          "Should execute ModifyVolume operation when PVC's VAC changes",
+			pvc:           basePVC,
+			pv:            basePV,
+			callCSIModify: true,
+		},
+		{
+			name:          "Should NOT modify if PVC managed by another CSI Driver",
+			pvc:           basePVC,
+			pv:            otherDriverPV,
+			callCSIModify: false,
+		},
+		{
+			name:          "Should NOT modify if PVC has empty Spec.VACName",
+			pvc:           createTestPVC(pvcName, "" /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/),
+			pv:            basePV,
+			callCSIModify: false,
+		},
+		{
+			name:          "Should NOT modify if PVC not in bound state",
+			pvc:           unboundPVC,
+			pv:            basePV,
+			callCSIModify: false,
+		},
+		{
+			name:          "Should NOT modify if PVC's PV not created yet",
+			pvc:           pvcWithUncreatedPV,
+			pv:            basePV,
+			callCSIModify: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := csi.NewMockClient(testDriverName, true, true, true, true, true, false)
+
+			initialObjects := []runtime.Object{test.pvc, test.pv, testVacObject, targetVacObject}
+			ctrlInstance, ctx := setupFakeK8sEnvironment(t, client, initialObjects)
+			defer ctx.Done()
+
+			err := ctrlInstance.syncPVC(pvcNamespace + "/" + pvcName)
+			if err != nil {
+				t.Errorf("for %s, unexpected error: %v", test.name, err)
+			}
+
+			modifyCallCount := client.GetModifyCount()
+			if test.callCSIModify && modifyCallCount == 0 {
+				t.Fatalf("for %s: expected csi modify call, no csi modify call was made", test.name)
+			}
+
+			if !test.callCSIModify && modifyCallCount > 0 {
+				t.Fatalf("for %s: expected no csi modify call, received csi modify request", test.name)
+			}
+		})
+	}
+}
+
+// setupFakeK8sEnvironment creates fake K8s environment and starts Informers and ModifyController
+func setupFakeK8sEnvironment(t *testing.T, client *csi.MockClient, initialObjects []runtime.Object) (*modifyController, context.Context) {
+	t.Helper()
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
+
+	/* Create fake kubeClient, Informers, and ModifyController */
+	kubeClient, informerFactory := fakeK8s(initialObjects)
+	pvInformer := informerFactory.Core().V1().PersistentVolumes()
+	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
+	vacInformer := informerFactory.Storage().V1beta1().VolumeAttributesClasses()
+
+	driverName, _ := client.GetDriverName(context.TODO())
+
+	csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
+	if err != nil {
+		t.Fatalf("Test %s: Unable to create modifier: %v", t.Name(), err)
+	}
+
+	controller := NewModifyController(driverName,
+		csiModifier, kubeClient,
+		0, false, informerFactory,
+		workqueue.DefaultTypedControllerRateLimiter[string]())
+
+	/* Start informers and ModifyController*/
+	stopCh := make(chan struct{})
+	informerFactory.Start(stopCh)
+
+	ctx := context.TODO()
+	go controller.Run(1, ctx)
+
+	/* Add initial objects to informer caches */
+	for _, obj := range initialObjects {
+		switch obj.(type) {
+		case *v1.PersistentVolume:
+			pvInformer.Informer().GetStore().Add(obj)
+		case *v1.PersistentVolumeClaim:
+			pvcInformer.Informer().GetStore().Add(obj)
+		case *storagev1beta1.VolumeAttributesClass:
+			vacInformer.Informer().GetStore().Add(obj)
+		default:
+			t.Fatalf("Test %s: Unknown initalObject type: %+v", t.Name(), obj)
+		}
+	}
+
+	ctrlInstance, _ := controller.(*modifyController)
+
+	return ctrlInstance, ctx
 }

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -120,7 +120,7 @@ func TestMarkControllerModifyVolumeStatus(t *testing.T) {
 			}
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, false, informerFactory,
+				time.Second, 2*time.Minute, false, informerFactory,
 				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
@@ -180,7 +180,7 @@ func TestUpdateConditionBasedOnError(t *testing.T) {
 			}
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, false, informerFactory,
+				time.Second, 2*time.Minute, false, informerFactory,
 				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
@@ -248,7 +248,7 @@ func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
 			}
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, false, informerFactory,
+				time.Second, 2*time.Minute, false, informerFactory,
 				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
@@ -314,7 +314,7 @@ func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
 			}
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
-				time.Second, false, informerFactory,
+				time.Second, 2*time.Minute, false, informerFactory,
 				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
@@ -346,10 +346,11 @@ func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
 
 			time.Sleep(time.Second * 2)
 
-			err = ctrlInstance.removePVCFromModifyVolumeUncertainCache(tc.pvc)
+			pvcKey, err := cache.MetaNamespaceKeyFunc(tc.pvc)
 			if err != nil {
-				t.Errorf("err deleting pvc: %v", tc.pvc)
+				t.Errorf("failed to extract pvc key from pvc %v", tc.pvc)
 			}
+			ctrlInstance.removePVCFromModifyVolumeUncertainCache(pvcKey)
 
 			deletedPVCKey, err := cache.MetaNamespaceKeyFunc(tc.pvc)
 			if err != nil {

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -28,12 +28,14 @@ import (
 const (
 	pvcName      = "foo"
 	pvcNamespace = "modify"
+	pvName       = "testPV"
 )
 
 var (
 	fsVolumeMode           = v1.PersistentVolumeFilesystem
 	testVac                = "test-vac"
 	targetVac              = "target-vac"
+	testDriverName         = "mock"
 	infeasibleErr          = status.Errorf(codes.InvalidArgument, "Parameters in VolumeAttributesClass is invalid")
 	finalErr               = status.Errorf(codes.Internal, "Final error")
 	pvcConditionInProgress = v1.PersistentVolumeClaimCondition{
@@ -390,7 +392,7 @@ func createTestPV(capacityGB int, pvcName, pvcNamespace string, pvcUID types.UID
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{
-					Driver:       "foo",
+					Driver:       testDriverName,
 					VolumeHandle: "foo",
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test


/kind feature

> /kind flake

**What this PR does / why we need it**:

This PR ensures infeasible PVC modifications (E.g. InvalidArgument) are retried at slower pace than normal failures (they are retried at the sidecar's `max-interval-retry`).

This prevents spamming relevant PVC with events when future ModifyVolume RPC Triggers will likely fail, like when a user's VolumeAttributeClass has incorrect parameters. 

See related resizer controller PR #418. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #407

**Special notes for your reviewer**:

This PR is stacked on top of the 2 commits of my unit test PR, #447. That should probably be reviewed first.  

This PR was tested alongside AWS EBS CSI Driver (ensuring that only 1 ModifyVolume RPC was triggered every `max-interval-retry`, if RPC failed with an infeasible error code). Ideally we would add csi mock e2e tests in k/k, but those do not exist yet for ModifyVolume.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Infeasible PVC modifications will be retried at a slower pace than normal failures.
```
