### PR TITLE
replace deprecated Queue and RateLimiter

### DIFF
--- a/cmd/csi-resizer/main.go
+++ b/cmd/csi-resizer/main.go
@@ -215,7 +215,7 @@ func main() {
 
 	resizerName := csiResizer.Name()
 	rc := controller.NewResizeController(resizerName, csiResizer, kubeClient, *resyncPeriod, informerFactory,
-		workqueue.NewItemExponentialFailureRateLimiter(*retryIntervalStart, *retryIntervalMax),
+		workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax),
 		*handleVolumeInUseError, *retryIntervalMax)
 
 	modifierName := csiModifier.Name()
@@ -223,7 +223,7 @@ func main() {
 	// Add modify controller only if the feature gate is enabled
 	if utilfeature.DefaultFeatureGate.Enabled(features.VolumeAttributesClass) {
 		mc = modifycontroller.NewModifyController(modifierName, csiModifier, kubeClient, *resyncPeriod, *extraModifyMetadata, informerFactory,
-			workqueue.NewItemExponentialFailureRateLimiter(*retryIntervalStart, *retryIntervalMax))
+			workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax))
 	}
 
 	run := func(ctx context.Context) {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -245,7 +245,7 @@ func TestController(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AnnotateFsResize, true)
 		controller := NewResizeController(driverName, csiResizer,
 			kubeClient, time.Second,
-			informerFactory, workqueue.DefaultControllerRateLimiter(),
+			informerFactory, workqueue.DefaultTypedControllerRateLimiter[string](),
 			!test.disableVolumeInUseErrorHandler,
 			2*time.Minute /* maxRetryInterval */)
 
@@ -410,7 +410,7 @@ func TestResizePVC(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AnnotateFsResize, true)
 			controller := NewResizeController(driverName, csiResizer,
 				kubeClient, time.Second,
-				informerFactory, workqueue.DefaultControllerRateLimiter(),
+				informerFactory, workqueue.DefaultTypedControllerRateLimiter[string](),
 				true, /* disableVolumeInUseErrorHandler*/
 				2*time.Minute /* maxRetryInterval */)
 

--- a/pkg/controller/expand_and_recover_test.go
+++ b/pkg/controller/expand_and_recover_test.go
@@ -173,7 +173,7 @@ func TestExpandAndRecover(t *testing.T) {
 			controller := NewResizeController(driverName,
 				csiResizer, kubeClient,
 				time.Second, informerFactory,
-				workqueue.DefaultControllerRateLimiter(), true /*handleVolumeInUseError*/, 2*time.Minute /*maxRetryInterval*/)
+				workqueue.DefaultTypedControllerRateLimiter[string](), true /*handleVolumeInUseError*/, 2*time.Minute /*maxRetryInterval*/)
 
 			ctrlInstance, _ := controller.(*resizeController)
 			recorder := record.NewFakeRecorder(10)

--- a/pkg/controller/resize_status_test.go
+++ b/pkg/controller/resize_status_test.go
@@ -94,7 +94,7 @@ func TestResizeFunctions(t *testing.T) {
 			controller := NewResizeController(driverName,
 				csiResizer, kubeClient,
 				time.Second, informerFactory,
-				workqueue.DefaultControllerRateLimiter(),
+				workqueue.DefaultTypedControllerRateLimiter[string](),
 				true, /*handleVolumeInUseError*/
 				2*time.Minute /*maxRetryInterval*/)
 

--- a/pkg/modifycontroller/controller_test.go
+++ b/pkg/modifycontroller/controller_test.go
@@ -87,7 +87,7 @@ func TestController(t *testing.T) {
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
 				time.Second, false, informerFactory,
-				workqueue.DefaultControllerRateLimiter())
+				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
 
@@ -188,7 +188,7 @@ func TestModifyPVC(t *testing.T) {
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
 				time.Second, false, informerFactory,
-				workqueue.DefaultControllerRateLimiter())
+				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
 

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -119,7 +119,7 @@ func TestMarkControllerModifyVolumeStatus(t *testing.T) {
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
 				time.Second, false, informerFactory,
-				workqueue.DefaultControllerRateLimiter())
+				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
 
@@ -179,7 +179,7 @@ func TestUpdateConditionBasedOnError(t *testing.T) {
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
 				time.Second, false, informerFactory,
-				workqueue.DefaultControllerRateLimiter())
+				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
 
@@ -247,7 +247,7 @@ func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
 				time.Second, false, informerFactory,
-				workqueue.DefaultControllerRateLimiter())
+				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
 
@@ -313,7 +313,7 @@ func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
 				time.Second, false, informerFactory,
-				workqueue.DefaultControllerRateLimiter())
+				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
 

--- a/pkg/modifycontroller/modify_volume_test.go
+++ b/pkg/modifycontroller/modify_volume_test.go
@@ -136,7 +136,7 @@ func TestModify(t *testing.T) {
 			controller := NewModifyController(driverName,
 				csiModifier, kubeClient,
 				time.Second, test.withExtraMetadata, informerFactory,
-				workqueue.DefaultControllerRateLimiter())
+				workqueue.DefaultTypedControllerRateLimiter[string]())
 
 			ctrlInstance, _ := controller.(*modifyController)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

replace deprecated Queue and RateLimiter

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #416 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
