### PR TITLE
Prow update master

### DIFF
--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -199,7 +199,7 @@ kindest/node:v1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fc
 # If the deployment script is called with CSI_PROW_TEST_DRIVER=<file name> as
 # environment variable, then it must write a suitable test driver configuration
 # into that file in addition to installing the driver.
-configvar CSI_PROW_DRIVER_VERSION "v1.12.0" "CSI driver version"
+configvar CSI_PROW_DRIVER_VERSION "v1.15.0" "CSI driver version"
 configvar CSI_PROW_DRIVER_REPO https://github.com/kubernetes-csi/csi-driver-host-path "CSI driver repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_DEPLOYMENT_SUFFIX "" "additional suffix in kubernetes-x.yy[suffix].yaml files"
@@ -624,7 +624,7 @@ start_cluster () {
             go_version="$(go_version_for_kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
             # Changing into the Kubernetes source code directory is a workaround for https://github.com/kubernetes-sigs/kind/issues/1910
             # shellcheck disable=SC2046
-            (cd "${CSI_PROW_WORK}/src/kubernetes" && run_with_go "$go_version" kind build node-image --image csiprow/node:latest --kube-root "${CSI_PROW_WORK}/src/kubernetes") || die "'kind build node-image' failed"
+            (cd "${CSI_PROW_WORK}/src/kubernetes" && run_with_go "$go_version" kind build node-image "${CSI_PROW_WORK}/src/kubernetes" --image csiprow/node:latest) || die "'kind build node-image' failed"
             csi_prow_kind_have_kubernetes=true
         fi
         image="csiprow/node:latest"

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -441,7 +441,8 @@ run_with_go () {
     else
         version=local
     fi
-    GOTOOLCHAIN=$version run "$@"
+    # Set GOMODCACHE to make sure Kubernetes does not need to download again.
+    GOTOOLCHAIN=$version GOMODCACHE="$(go env GOMODCACHE)" run "$@"
 }
 
 # Ensure that we have the desired version of kind.

--- a/release-tools/pull-test.sh
+++ b/release-tools/pull-test.sh
@@ -20,6 +20,11 @@
 
 set -ex
 
+# Prow checks out repos with --filter=blob:none. This breaks
+# "git subtree pull" unless we enable fetching missing file content.
+GIT_NO_LAZY_FETCH=0
+export GIT_NO_LAZY_FETCH
+
 # It must be called inside the updated csi-release-tools repo.
 CSI_RELEASE_TOOLS_DIR="$(pwd)"
 


### PR DESCRIPTION
/kind cleanup

Update release-tools according to https://github.com/kubernetes-csi/csi-release-tools/issues/7

Squashed 'release-tools/' changes from 227577e0..734c2b95

[734c2b95](https://github.com/kubernetes-csi/csi-release-tools/commit/734c2b95) Merge [pull request #265](https://github.com/kubernetes-csi/csi-release-tools/pull/265) from Rakshith-R/consider-main-branch
[f95c855b](https://github.com/kubernetes-csi/csi-release-tools/commit/f95c855b) Merge [pull request #262](https://github.com/kubernetes-csi/csi-release-tools/pull/262) from huww98/golang-toolchain
[3c8d966f](https://github.com/kubernetes-csi/csi-release-tools/commit/3c8d966f) Treat main branch as equivalent to master branch
[e31de525](https://github.com/kubernetes-csi/csi-release-tools/commit/e31de525) Merge [pull request #261](https://github.com/kubernetes-csi/csi-release-tools/pull/261) from huww98/golang
[fd153a9e](https://github.com/kubernetes-csi/csi-release-tools/commit/fd153a9e) Bump golang to 1.23.1
[a8b3d050](https://github.com/kubernetes-csi/csi-release-tools/commit/a8b3d050) pull-test.sh: fix "git subtree pull" errors
[6b05f0fc](https://github.com/kubernetes-csi/csi-release-tools/commit/6b05f0fc) use new GOTOOLCHAIN env to manage go version

git-subtree-dir: release-tools
git-subtree-split: 734c2b950c4b31f64b63052c64ffa5929d1c9b97

```release-note
NONE
```
