### PR TITLE
Disable node expansion if not required

### DIFF
--- a/pkg/controller/resize_status.go
+++ b/pkg/controller/resize_status.go
@@ -178,6 +178,7 @@ func (ctrl *resizeController) markOverallExpansionAsFinished(
 		newPVC.Status.AllocatedResourceStatuses = resourceStatusMap
 	}
 
+	// this will ensure that kubelet does not try to resize volume again
 	newPVC = ctrl.addNodeExpansionNotRequiredAnnotation(newPVC)
 
 	updatedPVC, err := util.PatchClaim(ctrl.kubeClient, pvc, newPVC, true /* addResourceVersionCheck */)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -53,6 +53,8 @@ var (
 	// Its value will be set by the external-resizer when it deems that filesystem resize is required after resizing volume.
 	// Its value will be used by pv_controller to determine pvc's status capacity when binding pvc and pv.
 	AnnPreResizeCapacity = "volume.alpha.kubernetes.io/pre-resize-capacity"
+
+	NodeExpansionNotRequired = "volume.kubernetes.io/node-expansion-not-required"
 )
 
 // MergeResizeConditionsOfPVC updates pvc with requested resize conditions


### PR DESCRIPTION
Use annotation for finalizing node expansion not required.
