### PR TITLE
Fix PVC ModifyVolume conditions

### DIFF
--- a/pkg/controller/expand_and_recover.go
+++ b/pkg/controller/expand_and_recover.go
@@ -222,7 +222,7 @@ func (ctrl *resizeController) callResizeOnPlugin(
 		if util.IsFinalError(err) {
 			var markExpansionFailedError error
 			ctrl.finalErrorPVCs.Insert(pvcKey)
-			if util.IsInfeasibleError(err) {
+			if util.IsResizeInfeasibleError(err) {
 				pvc, markExpansionFailedError = ctrl.markControllerExpansionInfeasible(pvc, err)
 				if markExpansionFailedError != nil {
 					return pvc, pv, fmt.Errorf("resizing failed in controller with %v but failed to update PVC %s with: %v", err, klog.KObj(pvc), markExpansionFailedError)

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -397,9 +397,11 @@ func createTestPV(capacityGB int, pvcName, pvcNamespace string, pvcUID types.UID
 					VolumeHandle: "foo",
 				},
 			},
-			VolumeMode:                volumeMode,
-			VolumeAttributesClassName: &vacName,
+			VolumeMode: volumeMode,
 		},
+	}
+	if vacName != "" {
+		pv.Spec.VolumeAttributesClassName = &vacName
 	}
 	if len(pvcName) > 0 {
 		pv.Spec.ClaimRef = &v1.ObjectReference{

--- a/pkg/modifycontroller/modify_volume.go
+++ b/pkg/modifycontroller/modify_volume.go
@@ -37,8 +37,9 @@ const (
 
 // The return value bool is only used as a sentinel value when function returns without actually performing modification
 func (ctrl *modifyController) modify(pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error, bool) {
-	pvcSpecVacName := pvc.Spec.VolumeAttributesClassName
-	curVacName := pvc.Status.CurrentVolumeAttributesClassName
+	pvcSpecVACName := pvc.Spec.VolumeAttributesClassName
+	currentVacName := pvc.Status.CurrentVolumeAttributesClassName
+
 	pvcKey, err := cache.MetaNamespaceKeyFunc(pvc)
 	if err != nil {
 		return pvc, pv, err, false
@@ -50,39 +51,50 @@ func (ctrl *modifyController) modify(pvc *v1.PersistentVolumeClaim, pv *v1.Persi
 		return pvc, pv, delayModificationErr, false
 	}
 
-	if pvcSpecVacName != nil && curVacName == nil {
-		// First time adding VAC to a PVC
+	if currentModificationInfeasible(pvc) && isVacRolledBack(pvc) {
+		return ctrl.validateVACAndRollback(pvc, pv)
+	}
+
+	if pvcSpecVACName == nil {
+		return pvc, pv, nil, false
+	}
+
+	switch {
+	case currentVacName == nil:
 		return ctrl.validateVACAndModifyVolumeWithTarget(pvc, pv)
-	} else if pvcSpecVacName != nil && curVacName != nil && *pvcSpecVacName != *curVacName {
+	case *currentVacName != *pvcSpecVACName:
 		// Check if PVC in uncertain state
 		_, inUncertainState := ctrl.uncertainPVCs[pvcKey]
 		if !inUncertainState {
 			klog.V(3).InfoS("previous operation on the PVC failed with a final error, retrying")
 			return ctrl.validateVACAndModifyVolumeWithTarget(pvc, pv)
 		} else {
-			vac, err := ctrl.vacLister.Get(*pvcSpecVacName)
+			vac, err := ctrl.vacLister.Get(*pvcSpecVACName)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
-					ctrl.eventRecorder.Eventf(pvc, v1.EventTypeWarning, util.VolumeModifyFailed, "VAC "+*pvcSpecVacName+" does not exist.")
+					ctrl.eventRecorder.Eventf(pvc, v1.EventTypeWarning, util.VolumeModifyFailed, "VAC "+*pvcSpecVACName+" does not exist.")
 				}
 				return pvc, pv, err, false
 			}
-			return ctrl.controllerModifyVolumeWithTarget(pvc, pv, vac, pvcSpecVacName)
+			return ctrl.controllerModifyVolumeWithTarget(pvc, pv, vac, pvcSpecVACName)
 		}
 	}
-
-	// Rollback infeasible errors for recovery
-	if pvc.Status.ModifyVolumeStatus != nil && pvc.Status.ModifyVolumeStatus.Status == v1.PersistentVolumeClaimModifyVolumeInfeasible {
-		targetVacName := pvc.Status.ModifyVolumeStatus.TargetVolumeAttributesClassName
-		// Case 1: rollback to nil
-		// Case 2: rollback to previous VAC
-		if (pvcSpecVacName == nil && curVacName == nil && targetVacName != "") || (pvcSpecVacName != nil && curVacName != nil && *pvcSpecVacName == *curVacName && targetVacName != *curVacName) {
-			return ctrl.validateVACAndRollback(pvc, pv)
-		}
-	}
-
-	// No modification required
 	return pvc, pv, nil, false
+}
+
+func isVacRolledBack(pvc *v1.PersistentVolumeClaim) bool {
+	pvcSpecVacName := pvc.Spec.VolumeAttributesClassName
+	curVacName := pvc.Status.CurrentVolumeAttributesClassName
+	targetVacName := pvc.Status.ModifyVolumeStatus.TargetVolumeAttributesClassName
+	// Case 1: rollback to nil
+	// Case 2: rollback to previous VAC
+	return (pvcSpecVacName == nil && curVacName == nil && targetVacName != "") ||
+		(pvcSpecVacName != nil && curVacName != nil &&
+			*pvcSpecVacName == *curVacName && targetVacName != *curVacName)
+}
+
+func currentModificationInfeasible(pvc *v1.PersistentVolumeClaim) bool {
+	return pvc.Status.ModifyVolumeStatus != nil && pvc.Status.ModifyVolumeStatus.Status == v1.PersistentVolumeClaimModifyVolumeInfeasible
 }
 
 // func validateVACAndModifyVolumeWithTarget validate the VAC. The function sets pvc.Status.ModifyVolumeStatus
@@ -121,8 +133,12 @@ func (ctrl *modifyController) validateVACAndRollback(
 	// The controller does not triggers ModifyVolume because it is only
 	// for rollbacking infeasible errors
 	// Record an event to indicate that external resizer is rolling back this volume.
+	rollbackVACName := "nil"
+	if pvc.Spec.VolumeAttributesClassName != nil {
+		rollbackVACName = *pvc.Spec.VolumeAttributesClassName
+	}
 	ctrl.eventRecorder.Event(pvc, v1.EventTypeNormal, util.VolumeModify,
-		fmt.Sprintf("external resizer is rolling back volume %s with infeasible error", pvc.Name))
+		fmt.Sprintf("external resizer is rolling back volume %s with infeasible error to VAC %s", pvc.Name, rollbackVACName))
 	// Mark pvc.Status.ModifyVolumeStatus as completed
 	pvc, pv, err := ctrl.markCotrollerModifyVolumeRollbackCompeleted(pvc, pv)
 	if err != nil {

--- a/pkg/modifycontroller/modify_volume_test.go
+++ b/pkg/modifycontroller/modify_volume_test.go
@@ -98,26 +98,6 @@ func TestModify(t *testing.T) {
 				"csi.storage.k8s.io/pv/name":       "testPV",
 			},
 		},
-		{
-			name:                                     "modify volume rollback succeeds for infeasible errors",
-			pvc:                                      createTestPVC(pvcName, testVac /*vacName*/, testVac /*curVacName*/, targetVac /*targetVacName*/, v1.PersistentVolumeClaimModifyVolumeInfeasible),
-			pv:                                       basePV,
-			vacExists:                                true,
-			expectModifyCall:                         false,
-			expectedModifyVolumeStatus:               nil,
-			expectedCurrentVolumeAttributesClassName: &testVac,
-			expectedPVVolumeAttributesClassName:      &testVac,
-		},
-		{
-			name:                                     "modify volume rollback to nil succeeds for infeasible errors",
-			pvc:                                      createTestPVC(pvcName, "" /*vacName*/, "" /*curVacName*/, targetVac /*targetVacName*/, v1.PersistentVolumeClaimModifyVolumeInfeasible),
-			pv:                                       createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, ""),
-			vacExists:                                true,
-			expectModifyCall:                         false,
-			expectedModifyVolumeStatus:               nil,
-			expectedCurrentVolumeAttributesClassName: nil,
-			expectedPVVolumeAttributesClassName:      nil,
-		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug 

**What this PR does / why we need it**:

Ensures PVCs associated with failed volume modifications always have both pvcModifyingVolumeCondition and pvcModifyVolumeErrorCondition

Also refactors `pkg/modify_volume.go` to have clearer flow and less duplicate logic.  

Draft NOTE: PR stacked on top of to prevent merge conflicts. Will need to rebase against merged PR before undrafting. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #483 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Ensure PVCs associated with failed volume modifications have correct conditions
```
