### PR TITLE
use t.Context() in test

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -261,9 +261,7 @@ func TestController(t *testing.T) {
 		stopCh := make(chan struct{})
 		informerFactory.Start(stopCh)
 
-		ctx := context.TODO()
-		defer ctx.Done()
-		go controller.Run(1, ctx)
+		go controller.Run(1, t.Context())
 
 		for _, obj := range initialObjects {
 			switch obj.(type) {

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -322,9 +322,7 @@ func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
 			stopCh := make(chan struct{})
 			informerFactory.Start(stopCh)
 
-			ctx := context.TODO()
-			defer ctx.Done()
-			success := ctrlInstance.init(ctx)
+			success := ctrlInstance.init(t.Context())
 			if !success {
 				t.Fatal("failed to init controller")
 			}

--- a/pkg/modifycontroller/modify_volume_test.go
+++ b/pkg/modifycontroller/modify_volume_test.go
@@ -109,8 +109,7 @@ func TestModify(t *testing.T) {
 			if test.vacExists {
 				initialObjects = append(initialObjects, targetVacObject)
 			}
-			ctrlInstance, ctx := setupFakeK8sEnvironment(t, client, initialObjects)
-			defer ctx.Done()
+			ctrlInstance := setupFakeK8sEnvironment(t, client, initialObjects)
 
 			// Action
 			pvc, pv, err, modifyCalled := ctrlInstance.modify(test.pvc, test.pv)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

`defer ctx.Done()` does not actually cancel the context.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
