### PR TITLE
extraModifyMetadata should not modify VAC in informer

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -211,7 +211,7 @@ func TestController(t *testing.T) {
 			disableVolumeInUseErrorHandler: true,
 		},
 	} {
-		client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true, false)
+		client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true)
 		driverName, _ := client.GetDriverName(context.TODO())
 
 		var expectedCap resource.Quantity
@@ -378,7 +378,7 @@ func TestResizePVC(t *testing.T) {
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true, false)
+			client := csi.NewMockClient("mock", test.NodeResize, true, false, true, true)
 			if test.expansionError != nil {
 				client.SetExpansionError(test.expansionError)
 			}

--- a/pkg/controller/expand_and_recover_test.go
+++ b/pkg/controller/expand_and_recover_test.go
@@ -159,7 +159,7 @@ func TestExpandAndRecover(t *testing.T) {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, true)
-			client := csi.NewMockClient("foo", !test.disableNodeExpansion, !test.disableControllerExpansion, false, true, true, false)
+			client := csi.NewMockClient("foo", !test.disableNodeExpansion, !test.disableControllerExpansion, false, true, true)
 			driverName, _ := client.GetDriverName(context.TODO())
 			if test.expansionError != nil {
 				client.SetExpansionError(test.expansionError)

--- a/pkg/controller/resize_status_test.go
+++ b/pkg/controller/resize_status_test.go
@@ -77,7 +77,7 @@ func TestResizeFunctions(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, true)
-			client := csi.NewMockClient("foo", true, true, false, true, true, false)
+			client := csi.NewMockClient("foo", true, true, false, true, true)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			pvc := test.pvc

--- a/pkg/modifier/csi_modifier_test.go
+++ b/pkg/modifier/csi_modifier_test.go
@@ -28,7 +28,7 @@ func TestNewModifier(t *testing.T) {
 			SupportsControllerModify: false,
 		},
 	} {
-		client := csi.NewMockClient("mock", false, false, c.SupportsControllerModify, false, false, false)
+		client := csi.NewMockClient("mock", false, false, c.SupportsControllerModify, false, false)
 		driverName := "mock-driver"
 		k8sClient, informerFactory := fakeK8s()
 		_, err := NewModifierFromClient(client, 0, k8sClient, informerFactory, false, driverName)

--- a/pkg/modifycontroller/controller_test.go
+++ b/pkg/modifycontroller/controller_test.go
@@ -65,7 +65,7 @@ func TestController(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Setup
-			client := csi.NewMockClient(testDriverName, true, true, true, true, true, false)
+			client := csi.NewMockClient(testDriverName, true, true, true, true, true)
 
 			initialObjects := []runtime.Object{test.pvc, test.pv, testVacObject, targetVacObject}
 			ctrlInstance := setupFakeK8sEnvironment(t, client, initialObjects)
@@ -116,7 +116,7 @@ func TestModifyPVC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := csi.NewMockClient(testDriverName, true, true, true, true, true, false)
+			client := csi.NewMockClient(testDriverName, true, true, true, true, true)
 			if test.modifyFailure {
 				client.SetModifyError(fmt.Errorf("fake modification error"))
 			}
@@ -217,7 +217,7 @@ func TestSyncPVC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := csi.NewMockClient(testDriverName, true, true, true, true, true, false)
+			client := csi.NewMockClient(testDriverName, true, true, true, true, true)
 
 			initialObjects := []runtime.Object{test.pvc, test.pv, testVacObject, targetVacObject}
 			ctrlInstance := setupFakeK8sEnvironment(t, client, initialObjects)
@@ -277,7 +277,7 @@ func TestInfeasibleRetry(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Setup
-			client := csi.NewMockClient(testDriverName, true, true, true, true, true, false)
+			client := csi.NewMockClient(testDriverName, true, true, true, true, true)
 			if test.csiModifyError != nil {
 				client.SetModifyError(test.csiModifyError)
 			}

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -104,7 +104,7 @@ func TestMarkControllerModifyVolumeStatus(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			client := csi.NewMockClient("foo", true, true, true, true, true, false)
+			client := csi.NewMockClient("foo", true, true, true, true, true)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			pvc := test.pvc
@@ -164,7 +164,7 @@ func TestUpdateConditionBasedOnError(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			client := csi.NewMockClient("foo", true, true, true, true, true, false)
+			client := csi.NewMockClient("foo", true, true, true, true, true)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			pvc := test.pvc
@@ -233,7 +233,7 @@ func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			client := csi.NewMockClient("foo", true, true, true, true, true, false)
+			client := csi.NewMockClient("foo", true, true, true, true, true)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			var initialObjects []runtime.Object
@@ -295,7 +295,7 @@ func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			client := csi.NewMockClient("foo", true, true, true, true, true, false)
+			client := csi.NewMockClient("foo", true, true, true, true, true)
 			driverName, _ := client.GetDriverName(context.TODO())
 
 			var initialObjects []runtime.Object

--- a/pkg/resizer/csi_resizer_test.go
+++ b/pkg/resizer/csi_resizer_test.go
@@ -72,7 +72,7 @@ func TestNewResizer(t *testing.T) {
 			Error: resizeNotSupportErr,
 		},
 	} {
-		client := csi.NewMockClient("mock", c.SupportsNodeResize, c.SupportsControllerResize, false, c.SupportsPluginControllerService, c.SupportsControllerSingleNodeMultiWriter, false)
+		client := csi.NewMockClient("mock", c.SupportsNodeResize, c.SupportsControllerResize, false, c.SupportsPluginControllerService, c.SupportsControllerSingleNodeMultiWriter)
 		driverName := "mock-driver"
 		k8sClient := fake.NewSimpleClientset()
 		resizer, err := NewResizerFromClient(client, 0, k8sClient, driverName)
@@ -106,7 +106,7 @@ func TestResizeWithSecret(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		client := csi.NewMockClient("mock", true, true, false, true, true, false)
+		client := csi.NewMockClient("mock", true, true, false, true, true)
 		secret := makeSecret("some-secret", "secret-namespace")
 		k8sClient := fake.NewSimpleClientset(secret)
 		pv := makeTestPV("test-csi", 2, "ebs-csi", "vol-abcde", tc.hasExpansionSecret)
@@ -164,7 +164,7 @@ func TestResizeMigratedPV(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			driverName := tc.driverName
-			client := csi.NewMockClient(driverName, true, true, false, true, true, false)
+			client := csi.NewMockClient(driverName, true, true, false, true, true)
 			client.SetCheckMigratedLabel()
 			k8sClient := fake.NewSimpleClientset()
 			resizer, err := NewResizerFromClient(client, 0, k8sClient, driverName)
@@ -433,7 +433,7 @@ func TestCanSupport(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			driverName := tc.driverName
-			client := csi.NewMockClient(driverName, true, true, false, true, true, false)
+			client := csi.NewMockClient(driverName, true, true, false, true, true)
 			k8sClient := fake.NewSimpleClientset()
 			resizer, err := NewResizerFromClient(client, 0, k8sClient, driverName)
 			if err != nil {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Also fix the test. Previous test does not actually cover the relevant code path.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
