### PR TITLE
modify: support rollback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kubernetes-csi/csi-lib-utils v0.22.0
-	golang.org/x/oauth2 v0.27.0 // indirect
-	golang.org/x/term v0.31.0 // indirect
 	google.golang.org/grpc v1.72.1
 	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
@@ -16,9 +14,8 @@ require (
 	k8s.io/component-base v0.34.0
 	k8s.io/csi-translation-lib v0.34.0
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 )
-
-require k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 
 require (
 	cel.dev/expr v0.24.0 // indirect
@@ -87,8 +84,10 @@ require (
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.39.0 // indirect
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -293,7 +293,7 @@ func (ctrl *resizeController) Run(workers int, ctx context.Context, wg *sync.Wai
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ReleaseLeaderElectionOnExit) {
-		for i := 0; i < workers; i++ {
+		for range workers {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -301,7 +301,7 @@ func (ctrl *resizeController) Run(workers int, ctx context.Context, wg *sync.Wai
 			}()
 		}
 	} else {
-		for i := 0; i < workers; i++ {
+		for range workers {
 			go wait.Until(ctrl.syncPVCs, 0, stopCh)
 		}
 	}

--- a/pkg/controller/resize_status_test.go
+++ b/pkg/controller/resize_status_test.go
@@ -30,16 +30,16 @@ func TestResizeFunctions(t *testing.T) {
 	}{
 		{
 			name:        "mark fs resize, with no other conditions",
-			pvc:         basePVC.Get(),
-			expectedPVC: basePVC.WithStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).Get(),
+			pvc:         basePVC().Get(),
+			expectedPVC: basePVC().WithStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, size resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markForPendingNodeExpansion(pvc)
 			},
 		},
 		{
 			name: "mark fs resize, when other resource statuses are present",
-			pvc:  basePVC.WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).Get(),
-			expectedPVC: basePVC.WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).
+			pvc:  basePVC().WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).Get(),
+			expectedPVC: basePVC().WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).
 				WithStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, _ resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markForPendingNodeExpansion(pvc)
@@ -47,25 +47,25 @@ func TestResizeFunctions(t *testing.T) {
 		},
 		{
 			name:        "mark controller resize in-progress",
-			pvc:         basePVC.Get(),
-			expectedPVC: basePVC.WithStorageResourceStatus(v1.PersistentVolumeClaimControllerResizeInProgress).Get(),
+			pvc:         basePVC().Get(),
+			expectedPVC: basePVC().WithStorageResourceStatus(v1.PersistentVolumeClaimControllerResizeInProgress).Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, q resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markControllerResizeInProgress(pvc, q, true)
 			},
 		},
 		{
 			name:        "mark controller resize failed",
-			pvc:         basePVC.Get(),
-			expectedPVC: basePVC.WithStorageResourceStatus(v1.PersistentVolumeClaimControllerResizeInfeasible).Get(),
+			pvc:         basePVC().Get(),
+			expectedPVC: basePVC().WithStorageResourceStatus(v1.PersistentVolumeClaimControllerResizeInfeasible).Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, q resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markControllerExpansionInfeasible(pvc, fmt.Errorf("things failed"))
 			},
 		},
 		{
 			name: "mark resize finished",
-			pvc: basePVC.WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).
+			pvc: basePVC().WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).
 				WithStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).Get(),
-			expectedPVC: basePVC.WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).
+			expectedPVC: basePVC().WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).
 				WithStorageResourceStatus("").Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, q resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markOverallExpansionAsFinished(pvc, q)

--- a/pkg/modifycontroller/controller.go
+++ b/pkg/modifycontroller/controller.go
@@ -63,8 +63,11 @@ type modifyController struct {
 	vacLister           storagev1listers.VolumeAttributesClassLister
 	vacListerSynced     cache.InformerSynced
 	extraModifyMetadata bool
-	// the key of the map is {PVC_NAMESPACE}/{PVC_NAME}
-	uncertainPVCs map[string]v1.PersistentVolumeClaim
+	// uncertainPVCs tracks PVCs that failed with non-final errors.
+	// We must not change the target when retrying.
+	// All in-progress PVCs are added here on initialization.
+	// The key of the map is {PVC_NAMESPACE}/{PVC_NAME}, value is not important now.
+	uncertainPVCs sync.Map
 	// slowSet tracks PVCs for which modification failed with infeasible error and should be retried at slower rate.
 	slowSet *slowset.SlowSet
 }
@@ -124,7 +127,6 @@ func NewModifyController(
 }
 
 func (ctrl *modifyController) initUncertainPVCs() error {
-	ctrl.uncertainPVCs = make(map[string]v1.PersistentVolumeClaim)
 	allPVCs, err := ctrl.pvcLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("Failed to list pvcs when init uncertain pvcs: %v", err)
@@ -136,7 +138,7 @@ func (ctrl *modifyController) initUncertainPVCs() error {
 			if err != nil {
 				return err
 			}
-			ctrl.uncertainPVCs[pvcKey] = *pvc.DeepCopy()
+			ctrl.uncertainPVCs.Store(pvcKey, pvc)
 		}
 	}
 
@@ -190,10 +192,7 @@ func (ctrl *modifyController) deletePVC(obj interface{}) {
 }
 
 func (ctrl *modifyController) init(ctx context.Context) bool {
-	informersSyncd := []cache.InformerSynced{ctrl.pvListerSynced, ctrl.pvcListerSynced}
-	informersSyncd = append(informersSyncd, ctrl.vacListerSynced)
-
-	if !cache.WaitForCacheSync(ctx.Done(), informersSyncd...) {
+	if !cache.WaitForCacheSync(ctx.Done(), ctrl.pvListerSynced, ctrl.pvcListerSynced, ctrl.vacListerSynced) {
 		klog.ErrorS(nil, "Cannot sync pod, pv, pvc or vac caches")
 		return false
 	}
@@ -224,7 +223,7 @@ func (ctrl *modifyController) Run(
 	go ctrl.slowSet.Run(stopCh)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ReleaseLeaderElectionOnExit) {
-		for i := 0; i < workers; i++ {
+		for range workers {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -232,7 +231,7 @@ func (ctrl *modifyController) Run(
 			}()
 		}
 	} else {
-		for i := 0; i < workers; i++ {
+		for range workers {
 			go wait.Until(ctrl.sync, 0, stopCh)
 		}
 	}

--- a/pkg/modifycontroller/controller.go
+++ b/pkg/modifycontroller/controller.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 // ModifyController watches PVCs and checks if they are requesting an modify operation.
@@ -133,7 +134,7 @@ func (ctrl *modifyController) initUncertainPVCs() error {
 		return err
 	}
 	for _, pvc := range allPVCs {
-		if pvc.Status.ModifyVolumeStatus != nil && (pvc.Status.ModifyVolumeStatus.Status == v1.PersistentVolumeClaimModifyVolumeInProgress || pvc.Status.ModifyVolumeStatus.Status == v1.PersistentVolumeClaimModifyVolumeInfeasible) {
+		if pvc.Status.ModifyVolumeStatus != nil && (pvc.Status.ModifyVolumeStatus.Status == v1.PersistentVolumeClaimModifyVolumeInProgress) {
 			pvcKey, err := cache.MetaNamespaceKeyFunc(pvc)
 			if err != nil {
 				return err
@@ -165,12 +166,11 @@ func (ctrl *modifyController) updatePVC(oldObj, newObj interface{}) {
 	}
 
 	// Only trigger modify volume if the following conditions are met
-	// 1. Non empty vac name
-	// 2. oldVacName != newVacName
-	// 3. PVC is in Bound state
-	oldVacName := oldPVC.Spec.VolumeAttributesClassName
-	newVacName := newPVC.Spec.VolumeAttributesClassName
-	if newVacName != nil && *newVacName != "" && (oldVacName == nil || *newVacName != *oldVacName) && oldPVC.Status.Phase == v1.ClaimBound {
+	// 1. VAC changed or modify finished (check pending modify request while we are modifying)
+	// 2. PVC is in Bound state
+	oldVacName := ptr.Deref(oldPVC.Spec.VolumeAttributesClassName, "")
+	newVacName := ptr.Deref(newPVC.Spec.VolumeAttributesClassName, "")
+	if (newVacName != oldVacName || newPVC.Status.ModifyVolumeStatus == nil) && newPVC.Status.Phase == v1.ClaimBound {
 		_, err := ctrl.pvLister.Get(oldPVC.Spec.VolumeName)
 		if err != nil {
 			klog.Errorf("Get PV %q of pvc %q in PVInformer cache failed: %v", oldPVC.Spec.VolumeName, klog.KObj(oldPVC), err)
@@ -282,15 +282,13 @@ func (ctrl *modifyController) syncPVC(key string) error {
 
 	// Only trigger modify volume if the following conditions are met
 	// 1. PV provisioned by CSI driver AND driver name matches local driver
-	// 2. Non-empty vac name
-	// 3. PVC is in Bound state
+	// 2. PVC is in Bound state
 	if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != ctrl.name {
 		klog.V(7).InfoS("Skipping PV provisioned by different driver", "PV", klog.KObj(pv))
 		return nil
 	}
 
-	vacName := pvc.Spec.VolumeAttributesClassName
-	if vacName != nil && *vacName != "" && pvc.Status.Phase == v1.ClaimBound {
+	if pvc.Status.Phase == v1.ClaimBound {
 		_, _, err, _ := ctrl.modify(pvc, pv)
 		if err != nil {
 			return err

--- a/pkg/modifycontroller/controller_test.go
+++ b/pkg/modifycontroller/controller_test.go
@@ -204,6 +204,11 @@ func TestSyncPVC(t *testing.T) {
 			callCSIModify: true,
 		},
 		{
+			name:          "Should NOT modify if PVC deleted",
+			pvc:           nil,
+			callCSIModify: false,
+		},
+		{
 			name:          "Should NOT modify if PVC not in bound state",
 			pvc:           unboundPVC,
 			pv:            basePV,
@@ -227,7 +232,13 @@ func TestSyncPVC(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := csi.NewMockClient(testDriverName, true, true, true, true, true)
 
-			initialObjects := []runtime.Object{test.pvc, test.pv, testVacObject, targetVacObject}
+			initialObjects := []runtime.Object{testVacObject, targetVacObject}
+			if test.pvc != nil {
+				initialObjects = append(initialObjects, test.pvc)
+			}
+			if test.pv != nil {
+				initialObjects = append(initialObjects, test.pv)
+			}
 			ctrlInstance := setupFakeK8sEnvironment(t, client, initialObjects)
 
 			err := ctrlInstance.syncPVC(pvcNamespace + "/" + pvcName)

--- a/pkg/modifycontroller/controller_test.go
+++ b/pkg/modifycontroller/controller_test.go
@@ -1,9 +1,9 @@
 package modifycontroller
 
 import (
-	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -321,6 +320,67 @@ func TestInfeasibleRetry(t *testing.T) {
 	}
 }
 
+// Intended to catch any race conditions in the controller
+func TestConcurrentSync(t *testing.T) {
+	cases := []struct {
+		name      string
+		waitCount int
+		err       error
+	}{
+		// TODO: This case is flaky due to fake client lacks resourceVersion support.
+		// {
+		// 	name:      "success",
+		// 	waitCount: 10,
+		// },
+		{
+			name:      "uncertain",
+			waitCount: 30,
+			err:       nonFinalErr,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := csi.NewMockClient(testDriverName, true, true, true, true, true)
+			client.SetModifyError(tc.err)
+
+			initialObjects := []runtime.Object{testVacObject, targetVacObject}
+			for i := range 10 {
+				initialObjects = append(initialObjects,
+					&v1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("foo-%d", i), Namespace: pvcNamespace},
+						Spec: v1.PersistentVolumeClaimSpec{
+							VolumeAttributesClassName: &testVac,
+							VolumeName:                fmt.Sprintf("testPV-%d", i),
+						},
+						Status: v1.PersistentVolumeClaimStatus{
+							Phase: v1.ClaimBound,
+						},
+					},
+					&v1.PersistentVolume{
+						ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("testPV-%d", i)},
+						Spec: v1.PersistentVolumeSpec{
+							PersistentVolumeSource: v1.PersistentVolumeSource{
+								CSI: &v1.CSIPersistentVolumeSource{
+									Driver:       testDriverName,
+									VolumeHandle: fmt.Sprintf("foo-%d", i),
+								},
+							},
+						},
+					},
+				)
+			}
+			ctrlInstance := setupFakeK8sEnvironment(t, client, initialObjects)
+			wg := sync.WaitGroup{}
+			t.Cleanup(wg.Wait)
+			go ctrlInstance.Run(3, t.Context(), &wg)
+
+			for client.GetModifyCount() < tc.waitCount {
+				time.Sleep(20 * time.Millisecond)
+			}
+		})
+	}
+}
+
 // setupFakeK8sEnvironment creates fake K8s environment and starts Informers and ModifyController
 func setupFakeK8sEnvironment(t *testing.T, client *csi.MockClient, initialObjects []runtime.Object) *modifyController {
 	t.Helper()
@@ -329,11 +389,9 @@ func setupFakeK8sEnvironment(t *testing.T, client *csi.MockClient, initialObject
 
 	/* Create fake kubeClient, Informers, and ModifyController */
 	kubeClient, informerFactory := fakeK8s(initialObjects)
-	pvInformer := informerFactory.Core().V1().PersistentVolumes()
-	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
-	vacInformer := informerFactory.Storage().V1().VolumeAttributesClasses()
 
-	driverName, _ := client.GetDriverName(context.TODO())
+	ctx := t.Context()
+	driverName, _ := client.GetDriverName(ctx)
 
 	csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
 	if err != nil {
@@ -346,26 +404,10 @@ func setupFakeK8sEnvironment(t *testing.T, client *csi.MockClient, initialObject
 		workqueue.DefaultTypedControllerRateLimiter[string]())
 
 	/* Start informers and ModifyController*/
-	stopCh := make(chan struct{})
-	informerFactory.Start(stopCh)
+	informerFactory.Start(ctx.Done())
 
-	go controller.Run(1, t.Context(), nil)
-
-	/* Add initial objects to informer caches */
-	for _, obj := range initialObjects {
-		switch obj.(type) {
-		case *v1.PersistentVolume:
-			pvInformer.Informer().GetStore().Add(obj)
-		case *v1.PersistentVolumeClaim:
-			pvcInformer.Informer().GetStore().Add(obj)
-		case *storagev1.VolumeAttributesClass:
-			vacInformer.Informer().GetStore().Add(obj)
-		default:
-			t.Fatalf("Test %s: Unknown initalObject type: %+v", t.Name(), obj)
-		}
-	}
-
-	ctrlInstance, _ := controller.(*modifyController)
+	ctrlInstance := controller.(*modifyController)
+	ctrlInstance.init(ctx)
 
 	return ctrlInstance
 }

--- a/pkg/modifycontroller/modify_status.go
+++ b/pkg/modifycontroller/modify_status.go
@@ -47,6 +47,7 @@ func (ctrl *modifyController) markControllerModifyVolumeStatus(
 	case v1.PersistentVolumeClaimModifyVolumeInProgress:
 		conditionMessage = "ModifyVolume operation in progress."
 	case v1.PersistentVolumeClaimModifyVolumeInfeasible:
+		newPVC.Status.ModifyVolumeStatus.TargetVolumeAttributesClassName = pvc.Status.ModifyVolumeStatus.TargetVolumeAttributesClassName
 		conditionMessage = "ModifyVolume failed with error" + err.Error() + ". Waiting for retry."
 	}
 	pvcCondition.Message = conditionMessage

--- a/pkg/modifycontroller/modify_status.go
+++ b/pkg/modifycontroller/modify_status.go
@@ -119,14 +119,9 @@ func (ctrl *modifyController) markControllerModifyVolumeCompleted(pvc *v1.Persis
 // markControllerModifyVolumeStatus clears all the conditions related to modify volume and only
 // leave other condition types
 func clearModifyVolumeConditions(conditions []v1.PersistentVolumeClaimCondition) []v1.PersistentVolumeClaimCondition {
-	knownConditions := []v1.PersistentVolumeClaimCondition{}
-	for _, value := range conditions {
-		// Only keep conditions that are not related to modify volume
-		if value.Type != v1.PersistentVolumeClaimVolumeModifyVolumeError && value.Type != v1.PersistentVolumeClaimVolumeModifyingVolume {
-			knownConditions = append(knownConditions, value)
-		}
-	}
-	return knownConditions
+	return slices.DeleteFunc(conditions, func(c v1.PersistentVolumeClaimCondition) bool {
+		return c.Type == v1.PersistentVolumeClaimVolumeModifyVolumeError || c.Type == v1.PersistentVolumeClaimVolumeModifyingVolume
+	})
 }
 
 // markRolledBack will clear the modifying conditions

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -14,13 +14,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
@@ -38,6 +36,7 @@ var (
 	testDriverName         = "mock"
 	infeasibleErr          = status.Errorf(codes.InvalidArgument, "Parameters in VolumeAttributesClass is invalid")
 	finalErr               = status.Errorf(codes.Internal, "Final error")
+	nonFinalErr            = status.Errorf(codes.Aborted, "Non-final error")
 	pvcConditionInProgress = v1.PersistentVolumeClaimCondition{
 		Type:    v1.PersistentVolumeClaimVolumeModifyingVolume,
 		Status:  v1.ConditionTrue,
@@ -268,110 +267,6 @@ func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
 
 			if diff := cmp.Diff(tc.expectedPV, pv); diff != "" {
 				t.Errorf("expected pvc %+v got %+v, diff is: %v", tc.expectedPV, pv, diff)
-			}
-		})
-	}
-}
-
-func TestRemovePVCFromModifyVolumeUncertainCache(t *testing.T) {
-	basePVC := testutil.MakeTestPVC([]v1.PersistentVolumeClaimCondition{})
-	basePVC.WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInProgress)
-	secondPVC := testutil.GetTestPVC("test-vol0", "2G", "1G", "", "")
-	secondPVC.Status.Phase = v1.ClaimBound
-	secondPVC.Status.ModifyVolumeStatus = &v1.ModifyVolumeStatus{}
-	secondPVC.Status.ModifyVolumeStatus.Status = v1.PersistentVolumeClaimModifyVolumeInfeasible
-
-	tests := []struct {
-		name string
-		pvc  *v1.PersistentVolumeClaim
-	}{
-		{
-			name: "should delete the target pvc but keep the others in the cache",
-			pvc:  basePVC.Get(),
-		},
-	}
-
-	for _, test := range tests {
-		tc := test
-		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
-			client := csi.NewMockClient("foo", true, true, true, true, true)
-			driverName, _ := client.GetDriverName(context.TODO())
-
-			var initialObjects []runtime.Object
-			initialObjects = append(initialObjects, test.pvc)
-			initialObjects = append(initialObjects, secondPVC)
-
-			kubeClient, informerFactory := fakeK8s(initialObjects)
-			pvInformer := informerFactory.Core().V1().PersistentVolumes()
-			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
-			podInformer := informerFactory.Core().V1().Pods()
-			vacInformer := informerFactory.Storage().V1().VolumeAttributesClasses()
-
-			csiModifier, err := modifier.NewModifierFromClient(client, 15*time.Second, kubeClient, informerFactory, false, driverName)
-			if err != nil {
-				t.Fatalf("Test %s: Unable to create modifier: %v", test.name, err)
-			}
-			controller := NewModifyController(driverName,
-				csiModifier, kubeClient,
-				time.Second, 2*time.Minute, false, informerFactory,
-				workqueue.DefaultTypedControllerRateLimiter[string]())
-
-			ctrlInstance, _ := controller.(*modifyController)
-
-			stopCh := make(chan struct{})
-			informerFactory.Start(stopCh)
-
-			success := ctrlInstance.init(t.Context())
-			if !success {
-				t.Fatal("failed to init controller")
-			}
-
-			for _, obj := range initialObjects {
-				switch obj.(type) {
-				case *v1.PersistentVolume:
-					pvInformer.Informer().GetStore().Add(obj)
-				case *v1.PersistentVolumeClaim:
-					pvcInformer.Informer().GetStore().Add(obj)
-				case *v1.Pod:
-					podInformer.Informer().GetStore().Add(obj)
-				case *storagev1.VolumeAttributesClass:
-					vacInformer.Informer().GetStore().Add(obj)
-				default:
-					t.Fatalf("Test %s: Unknown initalObject type: %+v", test.name, obj)
-				}
-			}
-
-			time.Sleep(time.Second * 2)
-
-			pvcKey, err := cache.MetaNamespaceKeyFunc(tc.pvc)
-			if err != nil {
-				t.Errorf("failed to extract pvc key from pvc %v", tc.pvc)
-			}
-			ctrlInstance.removePVCFromModifyVolumeUncertainCache(pvcKey)
-
-			deletedPVCKey, err := cache.MetaNamespaceKeyFunc(tc.pvc)
-			if err != nil {
-				t.Errorf("failed to extract pvc key from pvc %v", tc.pvc)
-			}
-			_, ok := ctrlInstance.uncertainPVCs[deletedPVCKey]
-			if ok {
-				t.Errorf("pvc %v should be deleted but it is still in the uncertainPVCs cache", tc.pvc)
-			}
-			if err != nil {
-				t.Errorf("err get pvc %v from uncertainPVCs: %v", tc.pvc, err)
-			}
-
-			notDeletedPVCKey, err := cache.MetaNamespaceKeyFunc(secondPVC)
-			if err != nil {
-				t.Errorf("failed to extract pvc key from secondPVC %v", secondPVC)
-			}
-			_, ok = ctrlInstance.uncertainPVCs[notDeletedPVCKey]
-			if !ok {
-				t.Errorf("pvc %v should not be deleted, uncertainPVCs list %v", secondPVC, ctrlInstance.uncertainPVCs)
-			}
-			if err != nil {
-				t.Errorf("err get pvc %v from uncertainPVCs: %v", secondPVC, err)
 			}
 		})
 	}

--- a/pkg/modifycontroller/modify_status_test.go
+++ b/pkg/modifycontroller/modify_status_test.go
@@ -69,8 +69,8 @@ func TestMarkControllerModifyVolumeStatus(t *testing.T) {
 	}{
 		{
 			name:               "mark modify volume as in progress",
-			pvc:                basePVC.Get(),
-			expectedPVC:        basePVC.WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInProgress).Get(),
+			pvc:                basePVC().Get(),
+			expectedPVC:        basePVC().WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInProgress).Get(),
 			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcConditionInProgress},
 			expectedErr:        nil,
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *modifyController) (*v1.PersistentVolumeClaim, error) {
@@ -79,8 +79,8 @@ func TestMarkControllerModifyVolumeStatus(t *testing.T) {
 		},
 		{
 			name:               "mark modify volume as failed",
-			pvc:                basePVC.Get(),
-			expectedPVC:        basePVC.WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInProgress).Get(),
+			pvc:                basePVC().WithConditions([]v1.PersistentVolumeClaimCondition{pvcConditionInProgress}).Get(),
+			expectedPVC:        basePVC().WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInProgress).Get(),
 			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcConditionError},
 			expectedErr:        nil,
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *modifyController) (*v1.PersistentVolumeClaim, error) {
@@ -89,8 +89,8 @@ func TestMarkControllerModifyVolumeStatus(t *testing.T) {
 		},
 		{
 			name:               "mark modify volume as infeasible",
-			pvc:                basePVC.Get(),
-			expectedPVC:        basePVC.WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInfeasible).Get(),
+			pvc:                basePVC().WithConditions([]v1.PersistentVolumeClaimCondition{pvcConditionInProgress}).Get(),
+			expectedPVC:        basePVC().WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumeInfeasible).Get(),
 			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcConditionInfeasible},
 			expectedErr:        infeasibleErr,
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *modifyController) (*v1.PersistentVolumeClaim, error) {
@@ -99,9 +99,9 @@ func TestMarkControllerModifyVolumeStatus(t *testing.T) {
 		},
 		{
 			name:               "mark modify volume as pending",
-			pvc:                basePVC.Get(),
-			expectedPVC:        basePVC.WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumePending).Get(),
-			expectedConditions: nil,
+			pvc:                basePVC().WithConditions([]v1.PersistentVolumeClaimCondition{pvcConditionInfeasible}).Get(),
+			expectedPVC:        basePVC().WithModifyVolumeStatus(v1.PersistentVolumeClaimModifyVolumePending).Get(),
+			expectedConditions: []v1.PersistentVolumeClaimCondition{pvcConditionInfeasible}, // not touched
 			expectedErr:        nil,
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *modifyController) (*v1.PersistentVolumeClaim, error) {
 				return ctrl.markControllerModifyVolumeStatus(pvc, v1.PersistentVolumeClaimModifyVolumePending, nil)
@@ -158,7 +158,7 @@ func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
 	basePV := createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, testVac)
 	expectedPV := basePV.DeepCopy()
 	expectedPV.Spec.VolumeAttributesClassName = &targetVac
-	expectedPVC := basePVC.WithCurrentVolumeAttributesClassName(targetVac).Get()
+	expectedPVC := basePVC().WithCurrentVolumeAttributesClassName(targetVac).Get()
 	expectedPVC.Status.ModifyVolumeStatus = nil
 
 	tests := []struct {
@@ -171,14 +171,14 @@ func TestMarkControllerModifyVolumeCompleted(t *testing.T) {
 	}{
 		{
 			name:        "update modify volume status to completed",
-			pvc:         basePVC.Get(),
+			pvc:         basePVC().Get(),
 			pv:          basePV,
 			expectedPVC: expectedPVC,
 			expectedPV:  expectedPV,
 		},
 		{
 			name:        "update modify volume status to completed, and clear conditions",
-			pvc:         basePVC.WithConditions([]v1.PersistentVolumeClaimCondition{pvcConditionInProgress}).Get(),
+			pvc:         basePVC().WithConditions([]v1.PersistentVolumeClaimCondition{pvcConditionInProgress}).Get(),
 			pv:          basePV,
 			expectedPVC: expectedPVC,
 			expectedPV:  expectedPV,

--- a/pkg/modifycontroller/modify_volume.go
+++ b/pkg/modifycontroller/modify_volume.go
@@ -58,7 +58,7 @@ func (ctrl *modifyController) modify(pvc *v1.PersistentVolumeClaim, pv *v1.Persi
 		return ctrl.validateVACAndModifyVolumeWithTarget(pvc, pv)
 	} else if pvcSpecVacName != nil && curVacName != nil && *pvcSpecVacName != *curVacName {
 		// Check if PVC in uncertain state
-		_, inUncertainState := ctrl.uncertainPVCs[pvcKey]
+		_, inUncertainState := ctrl.uncertainPVCs.Load(pvcKey)
 		if !inUncertainState {
 			klog.V(3).InfoS("previous operation on the PVC failed with a final error, retrying")
 			return ctrl.validateVACAndModifyVolumeWithTarget(pvc, pv)
@@ -120,7 +120,7 @@ func (ctrl *modifyController) controllerModifyVolumeWithTarget(
 	if err == nil {
 		klog.V(4).Infof("Update volumeAttributesClass of PV %q to %s succeeded", pv.Name, *pvcSpecVacName)
 		// Record an event to indicate that modify operation is successful.
-		ctrl.eventRecorder.Eventf(pvc, v1.EventTypeNormal, util.VolumeModifySuccess, fmt.Sprintf("external resizer modified volume %s with vac %s successfully ", pvc.Name, vacObj.Name))
+		ctrl.eventRecorder.Eventf(pvc, v1.EventTypeNormal, util.VolumeModifySuccess, fmt.Sprintf("external resizer modified volume %s with vac %s successfully", pvc.Name, vacObj.Name))
 		return pvc, pv, nil, true
 	} else {
 		errStatus, ok := status.FromError(err)
@@ -133,9 +133,9 @@ func (ctrl *modifyController) controllerModifyVolumeWithTarget(
 			if keyErr != nil {
 				return pvc, pv, keyErr, false
 			}
-			if !util.IsFinalError(keyErr) {
+			if !util.IsFinalError(err) {
 				// update conditions and cache pvc as uncertain
-				ctrl.uncertainPVCs[pvcKey] = *pvc
+				ctrl.uncertainPVCs.Store(pvcKey, pvc)
 			} else {
 				// Only InvalidArgument can be set to Infeasible state
 				// Final errors other than InvalidArgument will still be in InProgress state
@@ -147,10 +147,10 @@ func (ctrl *modifyController) controllerModifyVolumeWithTarget(
 					}
 					ctrl.markForSlowRetry(pvc, pvcKey)
 				}
-				ctrl.removePVCFromModifyVolumeUncertainCache(pvcKey)
+				ctrl.uncertainPVCs.Delete(pvcKey)
 			}
 		} else {
-			return pvc, pv, fmt.Errorf("cannot get error status from modify volume err: %v ", err), false
+			return pvc, pv, fmt.Errorf("cannot get error status from modify volume err: %v", err), false
 		}
 		// Record an event to indicate that modify operation is failed.
 		ctrl.eventRecorder.Eventf(pvc, v1.EventTypeWarning, util.VolumeModifyFailed, err.Error())

--- a/pkg/modifycontroller/modify_volume_test.go
+++ b/pkg/modifycontroller/modify_volume_test.go
@@ -60,11 +60,11 @@ func TestModify(t *testing.T) {
 		},
 		{
 			name:             "vac does not exist, no modification and set ModifyVolumeStatus to pending",
-			pvc:              createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, "" /*targetVacName*/),
+			pvc:              createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, "whatever" /*targetVacName*/),
 			pv:               basePV,
 			expectModifyCall: false,
 			expectedModifyVolumeStatus: &v1.ModifyVolumeStatus{
-				TargetVolumeAttributesClassName: targetVac,
+				TargetVolumeAttributesClassName: "whatever",
 				Status:                          v1.PersistentVolumeClaimModifyVolumePending,
 			},
 			expectedCurrentVolumeAttributesClassName: &testVac,

--- a/pkg/modifycontroller/modify_volume_test.go
+++ b/pkg/modifycontroller/modify_volume_test.go
@@ -33,7 +33,7 @@ var (
 )
 
 func TestModify(t *testing.T) {
-	basePVC := createTestPVC(pvcName, testVac /*vacName*/, testVac /*curVacName*/, testVac /*targetVacName*/)
+	basePVC := createTestPVC(pvcName, testVac /*vacName*/, testVac /*curVacName*/, "" /*targetVacName*/)
 	basePV := createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, testVac)
 
 	var tests = []struct {
@@ -220,9 +220,12 @@ func createTestPVC(pvcName string, vacName string, curVacName string, targetVacN
 			CurrentVolumeAttributesClassName: &curVacName,
 			ModifyVolumeStatus: &v1.ModifyVolumeStatus{
 				TargetVolumeAttributesClassName: targetVacName,
-				Status:                          "",
+				Status:                          v1.PersistentVolumeClaimModifyVolumeInfeasible,
 			},
 		},
+	}
+	if targetVacName == "" {
+		pvc.Status.ModifyVolumeStatus = nil
 	}
 	return pvc
 }

--- a/pkg/modifycontroller/modify_volume_test.go
+++ b/pkg/modifycontroller/modify_volume_test.go
@@ -1,6 +1,8 @@
 package modifycontroller
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -143,6 +145,44 @@ func TestModify(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestModifyUncertain(t *testing.T) {
+	basePVC := createTestPVC(pvcName, targetVac /*vacName*/, testVac /*curVacName*/, targetVac /*targetVacName*/)
+	basePVC.Status.ModifyVolumeStatus.Status = v1.PersistentVolumeClaimModifyVolumeInProgress
+	basePV := createTestPV(1, pvcName, pvcNamespace, "foobaz" /*pvcUID*/, &fsVolumeMode, testVac)
+
+	client := csi.NewMockClient(testDriverName, true, true, true, true, true)
+	initialObjects := []runtime.Object{testVacObject, targetVacObject, basePVC, basePV}
+	ctrlInstance := setupFakeK8sEnvironment(t, client, initialObjects)
+
+	pvcKey := fmt.Sprintf("%s/%s", pvcNamespace, pvcName)
+	assertUncertain := func(uncertain bool) {
+		t.Helper()
+		_, ok := ctrlInstance.uncertainPVCs.Load(pvcKey)
+		if ok != uncertain {
+			t.Fatalf("expected uncertain state to be %v, got %v", uncertain, ok)
+		}
+	}
+
+	// initialized to uncertain
+	assertUncertain(true)
+
+	client.SetModifyError(finalErr)
+	pvc, pv, err, _ := ctrlInstance.modify(basePVC, basePV)
+	if !errors.Is(err, finalErr) {
+		t.Fatalf("expected error to be %v, got %v", finalErr, err)
+	}
+	// should clear uncertain state
+	assertUncertain(false)
+
+	client.SetModifyError(nonFinalErr)
+	_, _, err, _ = ctrlInstance.modify(pvc, pv)
+	if !errors.Is(err, nonFinalErr) {
+		t.Fatalf("expected error to be %v, got %v", nonFinalErr, err)
+	}
+	// should enter uncertain state again
+	assertUncertain(true)
 }
 
 func createTestPVC(pvcName string, vacName string, curVacName string, targetVacName string) *v1.PersistentVolumeClaim {

--- a/pkg/testutil/test_util.go
+++ b/pkg/testutil/test_util.go
@@ -54,7 +54,7 @@ type pvcModifier struct {
 	pvc *v1.PersistentVolumeClaim
 }
 
-func MakePVC(conditions []v1.PersistentVolumeClaimCondition) pvcModifier {
+func MakePVC(conditions []v1.PersistentVolumeClaimCondition) func() pvcModifier {
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "resize"},
 		Spec: v1.PersistentVolumeClaimSpec{
@@ -76,10 +76,12 @@ func MakePVC(conditions []v1.PersistentVolumeClaimCondition) pvcModifier {
 			},
 		},
 	}
-	return pvcModifier{pvc}
+	return func() pvcModifier {
+		return pvcModifier{pvc.DeepCopy()}
+	}
 }
 
-func MakeTestPVC(conditions []v1.PersistentVolumeClaimCondition) pvcModifier {
+func MakeTestPVC(conditions []v1.PersistentVolumeClaimCondition) func() pvcModifier {
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: "modify"},
 		Spec: v1.PersistentVolumeClaimSpec{
@@ -106,7 +108,9 @@ func MakeTestPVC(conditions []v1.PersistentVolumeClaimCondition) pvcModifier {
 			},
 		},
 	}
-	return pvcModifier{pvc}
+	return func() pvcModifier {
+		return pvcModifier{pvc.DeepCopy()}
+	}
 }
 
 func (m pvcModifier) WithModifyVolumeStatus(status v1.PersistentVolumeClaimModifyVolumeStatus) pvcModifier {
@@ -147,7 +151,7 @@ func CompareConditions(realConditions, expectedConditions []v1.PersistentVolumeC
 }
 
 func (m pvcModifier) Get() *v1.PersistentVolumeClaim {
-	return m.pvc.DeepCopy()
+	return m.pvc
 }
 
 func (m pvcModifier) WithStorageResourceStatus(status v1.ClaimResourceStatus) pvcModifier {

--- a/pkg/testutil/test_util.go
+++ b/pkg/testutil/test_util.go
@@ -143,7 +143,8 @@ func CompareConditions(realConditions, expectedConditions []v1.PersistentVolumeC
 	}
 
 	for i, condition := range realConditions {
-		if condition.Type != expectedConditions[i].Type || condition.Message != expectedConditions[i].Message || condition.Status != expectedConditions[i].Status {
+		if condition.Type != expectedConditions[i].Type || condition.Message != expectedConditions[i].Message ||
+			condition.Status != expectedConditions[i].Status || condition.Reason != expectedConditions[i].Reason {
 			return false
 		}
 	}

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -24,6 +24,7 @@ const (
 	VolumeModify             = "VolumeModify"
 	VolumeModifyFailed       = "VolumeModifyFailed"
 	VolumeModifySuccess      = "VolumeModifySuccessful"
+	VolumeModifyCancelled    = "VolumeModifyCanceled"
 	FileSystemResizeRequired = "FileSystemResizeRequired"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Support rollback to VAC A if modifying from A to B failed with a final error.
This works just like we modifying it again to C on final error.

The significant changes in the sync logic:
- Always retry if pvc.Status.ModifyVolumeStatus is not nil, which means the
  last transation does not finish successfully.
- Keep reconciling to the previous target if spec is rolled back to nil, until
  it succeeds or we get an infeasible error. Then we just leave it at its
  current state and stop reconciling for it, since user may not care about it
  now.

See https://github.com/kubernetes/enhancements/pull/5482 for details

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

The first 2 commits are already included in my other PRs. Please review the last commit. I will rebase when the previous PRs are merged.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support rolling back when modify failed
```
