### PR TITLE
Fix version of kubernetes for alpha version of ReleaseLeaderElectionOnExit fg

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -42,7 +42,7 @@ const (
 	VolumeAttributesClass featuregate.Feature = "VolumeAttributesClass"
 
 	// owner: @rhrmo
-	// alpha: v1.35
+	// alpha: v1.34
 	//
 	// Releases leader election lease on sigterm / sigint.
 	ReleaseLeaderElectionOnExit featuregate.Feature = "ReleaseLeaderElectionOnExit"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In the comments of ReleaseLeaderElectionOnExit fg I put in the version of kubernetes to be 1.35, but it should be 1.34, this PR fixes it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
