### PR TITLE
probe VAC API availability

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -17,7 +17,12 @@ limitations under the License.
 package features
 
 import (
+	"slices"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/discovery"
 	"k8s.io/component-base/featuregate"
 )
 
@@ -58,4 +63,22 @@ var defaultResizerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec
 	RecoverVolumeExpansionFailure: {Default: true, PreRelease: featuregate.Beta},
 	VolumeAttributesClass:         {Default: true, PreRelease: featuregate.GA},
 	ReleaseLeaderElectionOnExit:   {Default: false, PreRelease: featuregate.Alpha},
+}
+
+// IsVolumeAttributesClassV1Enabled checks if the VolumeAttributesClass v1 API is enabled.
+func IsVolumeAttributesClassV1Enabled(d discovery.DiscoveryInterface) (bool, error) {
+	return resourceExists(d, "storage.k8s.io/v1", "VolumeAttributesClass")
+}
+
+func resourceExists(d discovery.DiscoveryInterface, groupVersion, kind string) (bool, error) {
+	res, err := d.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return slices.ContainsFunc(res.APIResources, func(r metav1.APIResource) bool {
+		return r.Kind == kind
+	}), nil
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fake "k8s.io/client-go/kubernetes/fake"
+)
+
+// kubectl get --raw '/apis/storage.k8s.io/v1'
+const (
+	discoveryV1_34 = `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"storage.k8s.io/v1","resources":[{"name":"csidrivers","singularName":"csidriver","namespaced":false,"kind":"CSIDriver","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"hL6j/rwBV5w="},{"name":"csinodes","singularName":"csinode","namespaced":false,"kind":"CSINode","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"Pe62DkZtjuo="},{"name":"csistoragecapacities","singularName":"csistoragecapacity","namespaced":true,"kind":"CSIStorageCapacity","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"xeVl+2Ly1kE="},{"name":"storageclasses","singularName":"storageclass","namespaced":false,"kind":"StorageClass","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sc"],"storageVersionHash":"K+m6uJwbjGY="},{"name":"volumeattachments","singularName":"volumeattachment","namespaced":false,"kind":"VolumeAttachment","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"tJx/ezt6UDU="},{"name":"volumeattachments/status","singularName":"","namespaced":false,"kind":"VolumeAttachment","verbs":["get","patch","update"]},{"name":"volumeattributesclasses","singularName":"volumeattributesclass","namespaced":false,"kind":"VolumeAttributesClass","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["vac"],"storageVersionHash":"Bl3MtjZ/n/s="}]}`
+	discoveryV1_32 = `{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"storage.k8s.io/v1","resources":[{"name":"csidrivers","singularName":"csidriver","namespaced":false,"kind":"CSIDriver","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"hL6j/rwBV5w="},{"name":"csinodes","singularName":"csinode","namespaced":false,"kind":"CSINode","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"Pe62DkZtjuo="},{"name":"csistoragecapacities","singularName":"csistoragecapacity","namespaced":true,"kind":"CSIStorageCapacity","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"xeVl+2Ly1kE="},{"name":"storageclasses","singularName":"storageclass","namespaced":false,"kind":"StorageClass","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sc"],"storageVersionHash":"K+m6uJwbjGY="},{"name":"volumeattachments","singularName":"volumeattachment","namespaced":false,"kind":"VolumeAttachment","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"tJx/ezt6UDU="},{"name":"volumeattachments/status","singularName":"","namespaced":false,"kind":"VolumeAttachment","verbs":["get","patch","update"]}]}`
+)
+
+func TestIsVolumeAttributesClassV1Enabled(t *testing.T) {
+	cases := []struct {
+		name    string
+		resp    string
+		enabled bool
+	}{
+		{
+			name:    "v1.34",
+			resp:    discoveryV1_34,
+			enabled: true,
+		}, {
+			name:    "v1.32",
+			resp:    discoveryV1_32,
+			enabled: false,
+		}, {
+			name:    "none",
+			resp:    `{}`,
+			enabled: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var l metav1.APIResourceList
+			err := json.Unmarshal([]byte(tc.resp), &l)
+			if err != nil {
+				t.Fatalf("error unmarshalling discovery response: %v", err)
+			}
+
+			client := fake.NewSimpleClientset()
+			client.Fake.Resources = append(client.Fake.Resources, &l)
+			enabled, err := IsVolumeAttributesClassV1Enabled(client.Discovery())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if enabled != tc.enabled {
+				t.Errorf("expected %v, got %v", tc.enabled, enabled)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

to determine the default value of VAC feature gate

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
VolumeAttributesClass feature gate defaults to false if VAC API v1 is not available
```
