### PR TITLE
remove TargetVolumeAttributesClassName change from CHANGELOG

### DIFF
--- a/CHANGELOG/CHANGELOG-2.0.md
+++ b/CHANGELOG/CHANGELOG-2.0.md
@@ -12,10 +12,6 @@
 
 ## Changes by Kind
 
-### API Change
-
-- TargetVolumeAttributesClassName is now valid for Pending status ([#510](https://github.com/kubernetes-csi/external-resizer/pull/510), [@huww98](https://github.com/huww98))
-
 ### Feature
 
 - Annotate PVCs that don't require node expansion, so as kubelet can skip them ([#496](https://github.com/kubernetes-csi/external-resizer/pull/496), [@gnufied](https://github.com/gnufied))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

TargetVolumeAttributesClassName is no longer valid for Pending status because the change is reverted in d03a1e7574c963eb50f1f5a5f47f7f97149cde91

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
