### PR TITLE
Fix broken link to CSI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This information reflects the head of this branch.
 
 | Compatible with CSI Version                                                                 | Container Image                    | [Min K8s Version](https://kubernetes-csi.github.io/docs/kubernetes-compatibility.html#minimum-version) | [Recommended K8s Version](https://kubernetes-csi.github.io/docs/kubernetes-compatibility.html#recommended-version) |
 |---------------------------------------------------------------------------------------------|------------------------------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| [CSI Spec v1.12.0](https://github.com/container-storage-interface/spec/releases/tag/v2.0.0) | k8s.gcr.io/sig-storage/csi-resizer | 1.16                                                                                                   | 1.34                                                                                                   |
+| [CSI Spec v1.12.0](https://github.com/container-storage-interface/spec/releases/tag/v1.12.0) | k8s.gcr.io/sig-storage/csi-resizer | 1.16                                                                                                   | 1.34                                                                                                   |
 
 ## Feature status
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
This PR fixes a broken link in the README.md file which points to the latest CSI spec.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
