### PR TITLE
Use credentials when calling ControllerModifyVolume

### DIFF
--- a/pkg/modifier/csi_modifier.go
+++ b/pkg/modifier/csi_modifier.go
@@ -76,7 +76,7 @@ func (r *csiModifier) Name() string {
 	return r.name
 }
 
-func (r *csiModifier) Modify(pv *v1.PersistentVolume, mutableParameters map[string]string) error {
+func (r *csiModifier) Modify(ctx context.Context, pv *v1.PersistentVolume, mutableParameters map[string]string) error {
 
 	var volumeID string
 	var source *v1.CSIPersistentVolumeSource
@@ -93,7 +93,7 @@ func (r *csiModifier) Modify(pv *v1.PersistentVolume, mutableParameters map[stri
 		return errors.New("empty volume handle")
 	}
 
-	secrets, err := r.getModifyCredentials(source.ControllerExpandSecretRef, pv.Annotations)
+	secrets, err := r.getModifyCredentials(ctx, source.ControllerExpandSecretRef, pv.Annotations)
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (r *csiModifier) Modify(pv *v1.PersistentVolume, mutableParameters map[stri
 
 // getModifyCredentials fetches the credential from the secret referenced in the annotations. When missing,
 // the default secretRef (CSIPersistentVolumeSource.ControllerExpandSecretRef) is used.
-func (r *csiModifier) getModifyCredentials(secretRef *v1.SecretReference, annotations map[string]string) (map[string]string, error) {
+func (r *csiModifier) getModifyCredentials(ctx context.Context, secretRef *v1.SecretReference, annotations map[string]string) (map[string]string, error) {
 	secretName := annotations[modifySecretNameAnn]
 	secretNamespace := annotations[modifySecretNamespaceAnn]
 	if secretNamespace == "" || secretName == "" {
@@ -123,7 +123,7 @@ func (r *csiModifier) getModifyCredentials(secretRef *v1.SecretReference, annota
 		secretNamespace = secretRef.Namespace
 	}
 
-	secret, err := r.k8sClient.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	secret, err := r.k8sClient.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting secret %s in namespace %s: %v", secretName, secretNamespace, err)
 	}

--- a/pkg/modifier/modifier.go
+++ b/pkg/modifier/modifier.go
@@ -17,6 +17,8 @@ limitations under the License.
 package modifier
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -25,5 +27,5 @@ type Modifier interface {
 	// Name returns the modifier's name.
 	Name() string
 	// Modify executes the modify operation of this PVC.
-	Modify(pv *v1.PersistentVolume, mutableParameters map[string]string) error
+	Modify(ctx context.Context, pv *v1.PersistentVolume, mutableParameters map[string]string) error
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Storage providers expect to obtain secrets from the
ControllerMoodifyVolume CSI procedure. Without these credentials, it may
not be possible to apply the parameters of a VolumeAttributeClass.

A CSIPersistentVolumeSource does not have ControllerModifySecretRef
(like ControllerExpandSecretRef), so in order to resolve credentials a
secret reference from annotations on the PersistentVolume are used:
 - `volume.kubernetes.io/controller-modify-secret-name`
 - `volume.kubernetes.io/controller-modify-secret-namespace`

In absence of these annotations, the ControllerExpandSecretRef of the
CSIPersistentVolumeSource used as a fallback.


**Which issue(s) this PR fixes**:

Related to kubernetes-csi/external-provisioner#1440

**Special notes for your reviewer**:

Posting this for early review. @gadididi is implementing `ControllerModifyVolume` in Ceph-CSI and found out about the missing secrets the hard way.

Approach has been discussed in [a thread at #csi](https://kubernetes.slack.com/archives/C8EJ01Z46/p1762534822913969).

/cc carlory gnufied

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
A StorageClass can use `csi.storage.k8s.io/controller-modify-secret-name` and `csi.storage.k8s.io/controller-modify-secret-namespace` to reference the credentials that should be used to modify a volume according to the parameters of a VolumeAttributeClass. In absence of these credentials, the credentials of `controller-expand-secret`are used as a fallback.
```
