### PR TITLE
Move feature to that restores pv size as annotation beta

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -29,6 +29,7 @@ import (
 const (
 	// owner: @sunpa93
 	// alpha: v1.22
+	// beta: v2.2
 	AnnotateFsResize featuregate.Feature = "AnnotateFsResize"
 
 	// owner: @gnufied
@@ -60,7 +61,7 @@ func init() {
 }
 
 var defaultResizerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AnnotateFsResize:              {Default: false, PreRelease: featuregate.Alpha},
+	AnnotateFsResize:              {Default: true, PreRelease: featuregate.Beta},
 	RecoverVolumeExpansionFailure: {Default: true, PreRelease: featuregate.GA},
 	VolumeAttributesClass:         {Default: true, PreRelease: featuregate.GA},
 	ReleaseLeaderElectionOnExit:   {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
This feature already is supported in `k/k` and requires no featuregate.  

It allows external-resizer to continue resizing volumes if PVC was deleted while resizing was pending on PV. 

```release-note
Allow resuming of resize operation if PVC is deleted while resize is pending
```

