### PR TITLE
fix: build with go1.26.4 to fix go CVE

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.26.3" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.26.4" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below
@@ -853,7 +853,8 @@ install_snapshot_controller() {
 
                   # Now replace registry and/or tag
                   NEW_TAG="csiprow"
-                  line="$(echo "$nocomments" | sed -e "s;$image;${name}:${NEW_TAG};")"
+                  escaped_image=$(printf '%s\n' "$image" | sed -e 's/[\/&;]/\\&/g')
+                  line="$(echo "$nocomments" | sed -e "s;${escaped_image};${name}:${NEW_TAG};")"
 	          echo "        using $line" >&2
               fi
               echo "$line"

--- a/verify-vendor.sh
+++ b/verify-vendor.sh
@@ -14,19 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -f Gopkg.toml ]; then
-    echo "Repo uses 'dep' for vendoring."
-    case "$(dep version 2>/dev/null | grep 'version *:')" in
-	*v0.[56789]*)
-            if dep check; then
-                echo "vendor up-to-date"
-            else
-                exit 1
-            fi
-            ;;
-	*) echo "skipping check, dep >= 0.5 required";;
-    esac
-elif [ -f go.mod ]; then
+if [ -f go.mod ]; then
     echo "Repo uses 'go mod'."
     # shellcheck disable=SC2235
     if [ "${JOB_NAME}" ] &&


### PR DESCRIPTION
Update csi-release-tools subtree to latest master.

```
git subtree pull --squash --prefix=release-tools https://github.com/kubernetes-csi/csi-release-tools.git master
```

```release-note
NONE
```