### PR TITLE
Update release-tools to fix spelling-check argument injection and refresh CI actions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           check_filenames: true

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get Go version
         id: go-version

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ images. Building from master creates the main `canary` image.
 Sharing and updating
 --------------------
 
-[`git subtree`](https://github.com/git/git/blob/HEAD/contrib/subtree/git-subtree.txt)
+[`git subtree`](https://github.com/git/git/blob/HEAD/contrib/subtree/git-subtree.adoc)
 is the recommended way of maintaining a copy of the rules inside the
 `release-tools` directory of a project. This way, it is possible to make
 changes also locally, test them and then push them back to the shared

--- a/verify-spelling.sh
+++ b/verify-spelling.sh
@@ -50,7 +50,7 @@ RES=0
 echo "Checking spelling..."
 ERROR_LOG="${TMP_DIR}/errors.log"
 cd "${ROOT}"
-git ls-files | grep -v vendor | xargs misspell > "${ERROR_LOG}"
+git ls-files -z | grep -z -v vendor | xargs -0 misspell -- > "${ERROR_LOG}"
 if [[ -s "${ERROR_LOG}" ]]; then
   sed 's/^/error: /' "${ERROR_LOG}" # add 'error' to each line to highlight in e2e status
   echo "Found spelling errors!"

--- a/verify-subtree.sh
+++ b/verify-subtree.sh
@@ -14,28 +14,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script verifies that the content of a directory managed
-# by "git subtree" has not been modified locally. It does that
-# by looking for commits that modify the files with the
-# subtree prefix (aka directory) while ignoring merge
-# commits. Merge commits are where "git subtree" pulls the
-# upstream files into the directory.
+# Verify that DIR is a clean copy of upstream csi-release-tools.
 #
-# Theoretically a developer can subvert this check by modifying files
-# in a merge commit, but in practice that shouldn't happen.
+# We read the upstream SHA from the "git-subtree-split" line that
+# "git subtree" writes into the pull commit's message, fetch that
+# SHA, and require its tree to equal HEAD:DIR.
 
 DIR="$1"
-if [ ! "$DIR" ]; then
+if [ -z "$DIR" ]; then
     echo "usage: $0 <directory>" >&2
     exit 1
 fi
 
-REV=$(git log -n1 --remove-empty --format=format:%H --no-merges -- "$DIR")
-if [ "$REV" ]; then
-    echo "Directory '$DIR' contains non-upstream changes:"
-    echo
-    git log --no-merges -- "$DIR"
+# csi-release-tools itself does not contain release-tools/.
+[ -d "$DIR" ] || exit 0
+
+UPSTREAM_URL="${UPSTREAM_URL:-https://github.com/kubernetes-csi/csi-release-tools.git}"
+
+REV=$(git log -1 --grep="^git-subtree-dir: $DIR\$" --format=%H)
+if [ -z "$REV" ]; then
+    echo "No subtree pull recorded for '$DIR'." >&2
     exit 1
-else
-    echo "$DIR is a clean copy of upstream."
 fi
+
+# A squashed PR with multiple pulls carries one trailer block per pull; the last one is HEAD.
+SPLIT=$(git log -1 --format=%B "$REV" | grep '^git-subtree-split: ' | tail -1 | cut -d' ' -f2)
+if [ -z "$SPLIT" ]; then
+    echo "Subtree commit $REV has no git-subtree-split trailer." >&2
+    exit 1
+fi
+
+git fetch --quiet --no-tags "$UPSTREAM_URL" "$SPLIT"
+
+if [ "$(git rev-parse "HEAD:$DIR")" = "$(git rev-parse "$SPLIT^{tree}")" ]; then
+    echo "$DIR matches upstream at $SPLIT."
+    exit 0
+fi
+
+echo "$DIR diverges from upstream at $SPLIT:" >&2
+git diff --stat "$SPLIT" "HEAD:$DIR" >&2
+exit 1


### PR DESCRIPTION
Update the release-tools subtree to the latest upstream csi-release-tools.

Notable changes:
- Fix argument injection vulnerability in verify-spelling.sh (misspell invocation now uses -0/-z file listing and an explicit `--` separator)
- Rework verify-subtree.sh to check the subtree's tree hash directly against the recorded git-subtree-split commit instead of scanning commit history, and to correctly handle repos with multiple squashed subtree pulls
- Bump actions/checkout from v6.0.2 to v6.0.3 in the codespell and trivy GitHub Actions workflows
- Fix broken link to the git-subtree documentation page in README.md

Squashed commit message from the subtree pull (individual upstream commits):

```
Squashed 'release-tools/' changes from 0d7d9d49..34632b81

34632b81 Merge pull request #305 from torredil/fix-verify-subtree-squash
00584f3a Merge pull request #311 from sandeep-gh-acc/fix-spelling-argument-injection-511325868
d52081ac Fix argument injection in verify-spelling.sh (b/511325868)
b598e492 Merge pull request #309 from mpatlasov/Update-broken-link-to-git-subtree
5a26ef84 Merge pull request #308 from kubernetes-csi/dependabot/github_actions/actions/checkout-6.0.3
06f1cd35 Update broken link to git-subtree doc page
fc5e536c Bump actions/checkout from 6.0.2 to 6.0.3
e343a065 Verify subtree contents instead of merge history

git-subtree-dir: release-tools
git-subtree-split: 34632b81244de6372b4147cb6c14ada91ef4e74b
```
