### PR TITLE
Add separate --resize-timeout and --modify-timeout flags

### DIFF
--- a/cmd/csi-resizer/main.go
+++ b/cmd/csi-resizer/main.go
@@ -68,7 +68,14 @@ var (
 
 	extraModifyMetadata = flag.Bool("extra-modify-metadata", false, "If set, add pv/pvc metadata to plugin modify requests as parameters.")
 
-	timeout = flag.Duration("timeout", 10*time.Second, "Timeout for waiting for CSI driver socket.")
+	timeout = flag.Duration("timeout", 10*time.Second, "Timeout for waiting for CSI driver socket. "+
+		"If set explicitly on the command line, this value also overrides --resize-timeout and "+
+		"--modify-timeout as the per-call timeout for ControllerExpandVolume and ControllerModifyVolume.")
+
+	resizeTimeout = flag.Duration("resize-timeout", 10*time.Second, "Timeout for ControllerExpandVolume calls. "+
+		"Ignored if --timeout is set explicitly on the command line.")
+	modifyTimeout = flag.Duration("modify-timeout", 10*time.Second, "Timeout for ControllerModifyVolume calls. "+
+		"Ignored if --timeout is set explicitly on the command line.")
 
 	retryIntervalStart = flag.Duration("retry-interval-start", time.Second, "Initial retry interval of failed volume resize. It exponentially increases with each failure, up to retry-interval-max.")
 	retryIntervalMax   = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval of failed volume resize.")
@@ -79,6 +86,25 @@ var (
 
 	version = "unknown"
 )
+
+// resolveOperationTimeouts determines the effective per-call timeouts for
+// ControllerExpandVolume and ControllerModifyVolume. --timeout only takes
+// precedence over --resize-timeout/--modify-timeout when it was explicitly
+// passed on the command line -- its default value must not mask explicitly-set
+// --resize-timeout/--modify-timeout values.
+func resolveOperationTimeouts(fs *flag.FlagSet, timeout, resizeTimeout, modifyTimeout time.Duration) (
+	effectiveResizeTimeout, effectiveModifyTimeout time.Duration) {
+	timeoutExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "timeout" {
+			timeoutExplicit = true
+		}
+	})
+	if timeoutExplicit {
+		return timeout, timeout
+	}
+	return resizeTimeout, modifyTimeout
+}
 
 func main() {
 	flag.Var(cflag.NewMapStringBool(&featureGates), "feature-gates", "A set of key=value paris that describe feature gates for alpha/experimental features for csi external resizer."+"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"))
@@ -94,6 +120,9 @@ func main() {
 		klog.ErrorS(err, "LoggingConfiguration is invalid")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
+
+	effectiveResizeTimeout, effectiveModifyTimeout := resolveOperationTimeouts(
+		flag.CommandLine, *timeout, *resizeTimeout, *modifyTimeout)
 
 	if standardflags.Configuration.ShowVersion {
 		fmt.Println(os.Args[0], version)
@@ -189,7 +218,7 @@ func main() {
 
 	csiResizer, err := resizer.NewResizerFromClient(
 		csiClient,
-		*timeout,
+		effectiveResizeTimeout,
 		kubeClient,
 		driverName)
 	if err != nil && errors.Is(err, resizer.ResizeNotSupportErr) {
@@ -201,7 +230,7 @@ func main() {
 
 	csiModifier, err := modifier.NewModifierFromClient(
 		csiClient,
-		*timeout,
+		effectiveModifyTimeout,
 		kubeClient,
 		informerFactory,
 		*extraModifyMetadata,

--- a/cmd/csi-resizer/main_test.go
+++ b/cmd/csi-resizer/main_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"testing"
+	"time"
+)
+
+func TestResolveOperationTimeouts(t *testing.T) {
+	tests := []struct {
+		name          string
+		explicitFlags []string
+		timeout       time.Duration
+		resizeTimeout time.Duration
+		modifyTimeout time.Duration
+		wantResize    time.Duration
+		wantModify    time.Duration
+	}{
+		{
+			name:          "nothing explicit, defaults used",
+			timeout:       10 * time.Second,
+			resizeTimeout: 10 * time.Second,
+			modifyTimeout: 10 * time.Second,
+			wantResize:    10 * time.Second,
+			wantModify:    10 * time.Second,
+		},
+		{
+			name:          "only resize-timeout and modify-timeout set explicitly",
+			explicitFlags: []string{"resize-timeout", "modify-timeout"},
+			timeout:       10 * time.Second,
+			resizeTimeout: 300 * time.Second,
+			modifyTimeout: 1800 * time.Second,
+			wantResize:    300 * time.Second,
+			wantModify:    1800 * time.Second,
+		},
+		{
+			name:          "timeout set explicitly overrides both, even with resize/modify also set",
+			explicitFlags: []string{"timeout", "resize-timeout", "modify-timeout"},
+			timeout:       120 * time.Second,
+			resizeTimeout: 300 * time.Second,
+			modifyTimeout: 1800 * time.Second,
+			wantResize:    120 * time.Second,
+			wantModify:    120 * time.Second,
+		},
+		{
+			name:          "timeout set explicitly at its own default value still overrides",
+			explicitFlags: []string{"timeout"},
+			timeout:       10 * time.Second,
+			resizeTimeout: 300 * time.Second,
+			modifyTimeout: 1800 * time.Second,
+			wantResize:    10 * time.Second,
+			wantModify:    10 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet(tt.name, flag.ContinueOnError)
+			fs.Duration("timeout", 10*time.Second, "")
+			fs.Duration("resize-timeout", 10*time.Second, "")
+			fs.Duration("modify-timeout", 10*time.Second, "")
+
+			var args []string
+			for _, name := range tt.explicitFlags {
+				switch name {
+				case "timeout":
+					args = append(args, "--timeout", tt.timeout.String())
+				case "resize-timeout":
+					args = append(args, "--resize-timeout", tt.resizeTimeout.String())
+				case "modify-timeout":
+					args = append(args, "--modify-timeout", tt.modifyTimeout.String())
+				}
+			}
+			if err := fs.Parse(args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			gotResize, gotModify := resolveOperationTimeouts(fs, tt.timeout, tt.resizeTimeout, tt.modifyTimeout)
+			if gotResize != tt.wantResize {
+				t.Errorf("resize timeout = %v, want %v", gotResize, tt.wantResize)
+			}
+			if gotModify != tt.wantModify {
+				t.Errorf("modify timeout = %v, want %v", gotModify, tt.wantModify)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
`--timeout` is currently used as the per-call timeout for both `ControllerExpandVolume`
and `ControllerModifyVolume`, with no way to configure them independently. This is a
problem for CSI drivers where a modify-volume operation can
potentially take much longer than a resize call, but operators have no way to give
modify volume a longer timeout without also inflating the resize timeout (or vice versa).

This PR adds two new flags, `--resize-timeout` and `--modify-timeout`, so each operation's
timeout can be set independently. Both default to the same value as `--timeout` (10s), so
behavior is unchanged for anyone not using the new flags.

For backwards compatibility, `--timeout` still works exactly as before: if it is explicitly
set on the command line, it overrides both `--resize-timeout` and `--modify-timeout`. If
`--timeout` is left at its default, `--resize-timeout`/`--modify-timeout` take effect
independently. `--timeout` is unchanged for its other use (CSI driver socket / GetPluginInfo).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add separate --resize-timeout and --modify-timeout flags
```
