### PR TITLE
record actual provisioned capacity in AllocatedResources

### DIFF
--- a/pkg/controller/expand_and_recover.go
+++ b/pkg/controller/expand_and_recover.go
@@ -282,7 +282,7 @@ func (ctrl *resizeController) callResizeOnPlugin(
 	}
 
 	if fsResizeRequired {
-		pvc, err = ctrl.markForPendingNodeExpansion(pvc)
+		pvc, err = ctrl.markForPendingNodeExpansion(pvc, updatedSize)
 		return pvc, pv, err
 	}
 	pvc, err = ctrl.markOverallExpansionAsFinished(pvc, updatedSize)

--- a/pkg/controller/expand_and_recover_test.go
+++ b/pkg/controller/expand_and_recover_test.go
@@ -34,6 +34,7 @@ func TestExpandAndRecover(t *testing.T) {
 		pv                         *v1.PersistentVolume
 		disableNodeExpansion       bool
 		disableControllerExpansion bool
+		expandedCapacity           resource.Quantity
 
 		// expectations of test
 		expectedResizeStatus                     v1.ClaimResourceStatus
@@ -52,6 +53,19 @@ func TestExpandAndRecover(t *testing.T) {
 			expectNodeExpansionNotRequiredAnnotation: false,
 			expectedAllocatedSize:                    resource.MustParse("2G"),
 			expectResizeCall:                         true,
+		},
+		{
+			// The driver returns a CapacityBytes larger than the request (e.g. it
+			// rounds up to its own granularity). AllocatedResources must follow
+			// the driver-returned capacity, not the raw request, so ResourceQuota
+			// counts the real provisioned size.
+			name:                  "driver returns capacity larger than request, allocated size follows driver capacity",
+			pvc:                   testutil.GetTestPVC("test-vol0", "2G", "1G", "", ""),
+			pv:                    createPV(1, "claim01", defaultNS, "test-uid", &fsVolumeMode),
+			expandedCapacity:      resource.MustParse("3G"),
+			expectedResizeStatus:  v1.PersistentVolumeClaimNodeResizePending,
+			expectedAllocatedSize: resource.MustParse("3G"),
+			expectResizeCall:      true,
 		},
 		{
 			name:                  "pvc.spec.size = pv.spec.size, resize_status=no_expansion_inprogress",
@@ -166,6 +180,9 @@ func TestExpandAndRecover(t *testing.T) {
 			driverName, _ := client.GetDriverName(context.TODO())
 			if test.expansionError != nil {
 				client.SetExpansionError(test.expansionError)
+			}
+			if !test.expandedCapacity.IsZero() {
+				client.SetExpandedCapacity(test.expandedCapacity.Value())
 			}
 
 			var initialObjects []runtime.Object

--- a/pkg/controller/resize_status.go
+++ b/pkg/controller/resize_status.go
@@ -68,7 +68,9 @@ func (ctrl *resizeController) markControllerResizeInProgress(
 
 // markForPendingNodeExpansion is new set of functions designed around feature RecoverVolumeExpansionFailure
 // which correctly sets pvc.Status.ResizeStatus
-func (ctrl *resizeController) markForPendingNodeExpansion(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+func (ctrl *resizeController) markForPendingNodeExpansion(
+	pvc *v1.PersistentVolumeClaim,
+	newSize resource.Quantity) (*v1.PersistentVolumeClaim, error) {
 	pvcCondition := v1.PersistentVolumeClaimCondition{
 		Type:               v1.PersistentVolumeClaimFileSystemResizePending,
 		Status:             v1.ConditionTrue,
@@ -84,6 +86,9 @@ func (ctrl *resizeController) markForPendingNodeExpansion(pvc *v1.PersistentVolu
 	newPVC = ctrl.removeNodeExpansionNotRequiredAnnotation(newPVC)
 
 	newPVC = mergeStorageResourceStatus(newPVC, v1.PersistentVolumeClaimNodeResizePending)
+	// Record the actual capacity returned by the controller so ResourceQuota
+	// counts the real provisioned size rather than the raw request.
+	newPVC = mergeStorageAllocatedResources(newPVC, newSize)
 	updatedPVC, err := util.PatchClaim(ctrl.kubeClient, pvc, newPVC, true /* addResourceVersionCheck */)
 
 	if err != nil {
@@ -167,6 +172,9 @@ func (ctrl *resizeController) markOverallExpansionAsFinished(
 
 	newPVC := pvc.DeepCopy()
 	newPVC.Status.Capacity[v1.ResourceStorage] = newSize
+	// Record the actual capacity returned by the controller so ResourceQuota
+	// counts the real provisioned size rather than the raw request.
+	newPVC = mergeStorageAllocatedResources(newPVC, newSize)
 	newPVC.Status.Conditions = util.MergeResizeConditionsOfPVC(pvc.Status.Conditions,
 		[]v1.PersistentVolumeClaimCondition{}, false /*keepOldResizeConditions*/)
 

--- a/pkg/controller/resize_status_test.go
+++ b/pkg/controller/resize_status_test.go
@@ -33,7 +33,7 @@ func TestResizeFunctions(t *testing.T) {
 			pvc:         basePVC().Get(),
 			expectedPVC: basePVC().WithStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).Get(),
 			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, size resource.Quantity) (*v1.PersistentVolumeClaim, error) {
-				return ctrl.markForPendingNodeExpansion(pvc)
+				return ctrl.markForPendingNodeExpansion(pvc, size)
 			},
 		},
 		{
@@ -41,8 +41,8 @@ func TestResizeFunctions(t *testing.T) {
 			pvc:  basePVC().WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).Get(),
 			expectedPVC: basePVC().WithResourceStatus(v1.ResourceCPU, v1.PersistentVolumeClaimControllerResizeInfeasible).
 				WithStorageResourceStatus(v1.PersistentVolumeClaimNodeResizePending).Get(),
-			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, _ resource.Quantity) (*v1.PersistentVolumeClaim, error) {
-				return ctrl.markForPendingNodeExpansion(pvc)
+			testFunc: func(pvc *v1.PersistentVolumeClaim, ctrl *resizeController, size resource.Quantity) (*v1.PersistentVolumeClaim, error) {
+				return ctrl.markForPendingNodeExpansion(pvc, size)
 			},
 		},
 		{

--- a/pkg/csi/mock_client.go
+++ b/pkg/csi/mock_client.go
@@ -41,6 +41,7 @@ type MockClient struct {
 	modifyCalled                            atomic.Int32
 	expansionError                          error
 	modifyError                             error
+	expandedCapacityBytes                   int64
 	checkMigratedLabel                      bool
 	usedSecrets                             atomic.Pointer[map[string]string]
 	usedCapability                          atomic.Pointer[csi.VolumeCapability]
@@ -84,6 +85,13 @@ func (c *MockClient) SetCheckMigratedLabel() {
 	c.checkMigratedLabel = true
 }
 
+// SetExpandedCapacity makes Expand return the given capacity as CapacityBytes
+// instead of the requested bytes, so tests can exercise a driver whose
+// realized capacity differs from the request.
+func (c *MockClient) SetExpandedCapacity(bytes int64) {
+	c.expandedCapacityBytes = bytes
+}
+
 func (c *MockClient) Expand(
 	ctx context.Context,
 	volumeID string,
@@ -107,6 +115,9 @@ func (c *MockClient) Expand(
 	c.expandCalled.Add(1)
 	c.usedSecrets.Store(&secrets)
 	c.usedCapability.Store(capability)
+	if c.expandedCapacityBytes > 0 {
+		return c.expandedCapacityBytes, c.supportsNodeResize, nil
+	}
 	return requestBytes, c.supportsNodeResize, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

After a successful `ControllerExpandVolume`, the external-resizer records the *requested* target (`pvcSpecSize`) in `pvc.Status.AllocatedResources` and never updates it to the actual capacity the CSI driver returned (`resp.CapacityBytes`). Since `RecoverVolumeExpansionFailure` (beta default-on in 1.32, GA in 1.34) makes `ResourceQuota` count `AllocatedResources` for PVC storage usage, the quota currently tracks the raw request rather than the real provisioned size. A driver whose realized capacity exceeds the request (e.g. it rounds up to its own granularity) leaves the difference uncounted.

This records the actual capacity returned by the controller in `AllocatedResources`, in the same status patch the resizer already issues after the gRPC (no extra API call), for both the filesystem-resize-required path (`markForPendingNodeExpansion`) and the no-FS-resize path (`markOverallExpansionAsFinished`). The accurate size is therefore counted as soon as the controller gRPC returns, even before kubelet finishes node-side filesystem expansion.

This matters specifically for volumes that are expanded but never mounted: `pvc.Status.Capacity` is set by kubelet on node-side resize, so for an unmounted volume it stays at the old size indefinitely — meaning even counting `status.capacity` for quota could be cheated by simply not mounting the volume. `AllocatedResources` is set by the resizer at the controller gRPC independent of mounting, so it is the right place to carry the mount-independent actual size.

This requires no kube-apiserver change: `AllocatedResources` is already quota-counted and already replenished on status-subresource updates, which are counted but not hard-rejected by the quota admission — so this does not block resize completion; the accurate usage simply lands in `ResourceQuota.Status.Used` and gates future allocations.

**Which issue(s) this PR fixes:**

Related upstream context:
- kubernetes/kubernetes#112281

**Special notes for your reviewer:**

- This only addresses volume *expansion*, not initial provisioning. `AllocatedResources` is a resize-only field (nil at provision time), so the create-time rounding gap is out of scope here.
- The change depends on the CSI driver reporting an accurate `CapacityBytes` from `ControllerExpandVolume`; if a driver echoes the request, the behavior is unchanged (actual == request).
- The resizer's recovery logic is unaffected: `AllocatedResources` is only overwritten on confirmed success (on uncertain/final errors the pre-gRPC target is retained), and re-targeting the already-allocated size is idempotent. `AllocatedResources` is never cleared on the gate-on path today, so this only changes the *value* of an already-present field on PVCs that have been resized.
- Tests: the new integrated case in `TestExpandAndRecover` ("driver returns capacity larger than request, allocated size follows driver capacity") runs the full `expandAndRecover` loop with a mock that returns a `CapacityBytes` larger than the request and asserts `AllocatedResources` follows the driver-returned value; it fails (records the request instead) without this change. `MockClient.SetExpandedCapacity` is opt-in so the mock's default byte-exact behavior — relied on by other tests — is unchanged.

**Does this PR introduce a user-facing change?**

```release-note
pvc.Status.AllocatedResources now records the actual capacity returned by the CSI driver, so ResourceQuota counts the real provisioned size.
```

**Additional documentation e.g. KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**

```docs

```
